### PR TITLE
Fixed a bug about switch scene

### DIFF
--- a/assets/scripts/Global/Menu.js
+++ b/assets/scripts/Global/Menu.js
@@ -77,7 +77,6 @@ cc.Class({
         this.contentPos = this.testList.getContentPosition();
         this.currentSceneUrl = url;
         this.isMenu = false;
-        this.testList.node.active = false;
         cc.director.loadScene(url, this.onLoadSceneFinish.bind(this));
         if (typeof cocosAnalytics !== 'undefined') {
             //Cocos Analytics service, to learn more please visit:
@@ -90,6 +89,7 @@ cc.Class({
 
     onLoadSceneFinish: function () {
         let url = this.currentSceneUrl;
+        this.testList.node.active = false;
         this.loadInstruction(url);
         if (this.isMenu && this.contentPos) {
             this.btnBack.node.active = false;


### PR DESCRIPTION
https://github.com/cocos-creator/fireball/issues/5171

问题：
点击切换场景，会显示空白，等待加载完成后，才会显示下个场景，造成两个场景之间有一段时间的空白。

因为将这个列表改成常驻节点了，所以在切换场景之前手动隐藏，造成了这个问题。
正确的逻辑应该是在回调中隐藏。