### PR TITLE
fix LoadRes_example bug, release asset error

### DIFF
--- a/assets/cases/05_scripting/07_asset_loading/LoadRes/LoadRes_example.js
+++ b/assets/cases/05_scripting/07_asset_loading/LoadRes/LoadRes_example.js
@@ -12,7 +12,7 @@ cc.Class({
 
     loadSpriteFrame: function () {
         var url = this._url[0];
-        this._clearResource(url);
+        this._clearResource(url, cc.SpriteAtlas);
         cc.loader.loadRes(url, cc.SpriteAtlas, (err, atlas) => {
             cc.loader.setAutoRelease(url, true);
             var node = new cc.Node();
@@ -25,8 +25,8 @@ cc.Class({
 
     loadPrefab: function () {
         var url = this._url[1];
-        this._clearResource(url);
-        cc.loader.loadRes(url, (err, prefab) => {
+        this._clearResource(url, cc.Prefab);
+        cc.loader.loadRes(url, cc.Prefab, (err, prefab) => {
             cc.loader.setAutoRelease(url, true);
             var node = cc.instantiate(prefab);
             this.content.addChild(node);
@@ -34,9 +34,9 @@ cc.Class({
         });
     },
 
-    _clearResource: function (url) {
+    _clearResource: function (url, type) {
         this.content.removeAllChildren(true);
-        var deps = cc.loader.getDependsRecursively(url);
-        cc.loader.release(deps);
+        var res = cc.loader.getRes(url, type);
+        cc.loader.release(res);
     }
 });


### PR DESCRIPTION
LoaRes 释放资源的时候需要传入类型，否则会导致释放失败，所以修改了一下范例用 getRes

@nantas  有空的时候合并一下