### PR TITLE
Fix DragonBones swtich scene issue

### DIFF
--- a/assets/cases/dragonbones/DragonBonesCtrl.js
+++ b/assets/cases/dragonbones/DragonBonesCtrl.js
@@ -298,7 +298,7 @@ cc.Class({
         for (var i = this._bullets.length - 1; i >= 0; i--)
         {
             var bullet = this._bullets[i];
-            bullet.doClean();
+            bullet.enabled = false;
         }
         this._bullets = [];
     },
@@ -562,6 +562,10 @@ var DragonBullet = cc.Class({
         }
 
         return false;
+    },
+
+    onDisable : function () {
+        this.doClean();
     },
 
     doClean : function() {


### PR DESCRIPTION
For https://github.com/cocos-creator/fireball/issues/6937

@jareguo 这里的问题是在切换场景时，DragonBones 的 onDisable 会去做 bullet 的 clean 操作，导致 bullet 直接 removeFromParent 移除。而 DragonBones 的 onDisable 调用是在下面的逻辑中发生的

https://github.com/cocos-creator/engine/blob/master/cocos2d/core/utils/base-node.js#L1024

由于 DragonBones 和 bullets 是在同一个父节点下，base-node 代码中的 children.length 发生了改变，循环开始时获取的 len 已经失效了，进而导致 node = children[i] 获取的是 undefined。

麻烦看下这里该如何优化逻辑，理论上来说任何在 onDisable 时操控同级节点（增删）的行为都会导致问题。