### PR TITLE
fix cocosAnalytics.isInited error for simulator

### DIFF
--- a/assets/scripts/Global/Menu.js
+++ b/assets/scripts/Global/Menu.js
@@ -44,7 +44,7 @@ cc.Class({
             this.sceneList = this.testList.content.getComponent('SceneList');
             this.sceneList.init(this);
         }
-        if (typeof cocosAnalytics !== 'undefined' && cocosAnalytics.isInited()) {
+        if (typeof cocosAnalytics !== 'undefined' && cocosAnalytics.isInited && cocosAnalytics.isInited()) {
             // Cocos Analytics service, to learn more please visit:
             // https://analytics.cocos.com/docs/
             cocosAnalytics.CAEvent.onEvent({
@@ -79,7 +79,7 @@ cc.Class({
         this.isMenu = false;
         this.testList.node.active = false;
         cc.director.loadScene(url, this.onLoadSceneFinish.bind(this));
-        if (typeof cocosAnalytics !== 'undefined' && cocosAnalytics.isInited()) {
+        if (typeof cocosAnalytics !== 'undefined' && cocosAnalytics.isInited && cocosAnalytics.isInited()) {
             // Cocos Analytics service, to learn more please visit:
             // https://analytics.cocos.com/docs/
             cocosAnalytics.CALevels.begin({


### PR DESCRIPTION
加个保护防止，在模拟器 cocosAnalytics.isInited undefined 的报错导致黑屏