### PR TITLE
fix 03_gameplay/DeviceMotionCtrl

### DIFF
--- a/assets/cases/03_gameplay/01_player_control/DeviceMotion/DeviceMotionCtrl.js
+++ b/assets/cases/03_gameplay/01_player_control/DeviceMotion/DeviceMotionCtrl.js
@@ -13,12 +13,12 @@ cc.Class({
         var screenSize = cc.view.getVisibleSize();
         this._range.x = screenSize.width / 2 - this.target.width / 2;
         this._range.y = screenSize.height / 2 - this.target.height / 2;
-        cc.systemEvent.setAccelerometerEnabled(true);
+        cc.inputManager.setAccelerometerEnabled(true);
         cc.systemEvent.on(cc.SystemEvent.EventType.DEVICEMOTION, this.onDeviceMotionEvent, this);
     },
 
     onDestroy () {
-        cc.systemEvent.setAccelerometerEnabled(false);
+        cc.inputManager.setAccelerometerEnabled(false);
         cc.systemEvent.off(cc.SystemEvent.EventType.DEVICEMOTION, this.onDeviceMotionEvent, this);
     },
 


### PR DESCRIPTION
参见官方文档 [设备重力感应事件](http://docs.cocos.com/creator/manual/zh/scripting/player-controls.html#%E8%AE%BE%E5%A4%87%E9%87%8D%E5%8A%9B%E4%BC%A0%E6%84%9F%E4%BA%8B%E4%BB%B6)

setAccelerometerEnabled 方法 由 cc.systemEvent 下变为 cc.inputmanager 下。

[示例 03_gameplay/01_player_control/DeviceMotion](https://github.com/cocos-creator/example-cases/blob/26fa4cf767a6ca48d36cbbc80420eded78544689/assets/cases/03_gameplay/01_player_control/DeviceMotion/DeviceMotionCtrl.js#L16) 与 [API 文档](http://docs.cocos.com/creator/api/zh/classes/SystemEvent.html?h=system) 未更新。