### PR TITLE
fix follow example error for fireball/issues/7286

### DIFF
--- a/assets/cases/collider/Platform/follow.js
+++ b/assets/cases/collider/Platform/follow.js
@@ -16,7 +16,7 @@ cc.Class({
         if (!this.target) {
             return;
         }
-        var follow = cc.follow(this.target, cc.rect(0,0, 2000,2000));
+        var follow = cc.follow(this.target, cc.rect(0, -5, 2000,2000));
         this.node.runAction(follow);
     }
 });


### PR DESCRIPTION
https://github.com/cocos-creator/fireball/issues/7286

由于加入了 camera ，所以需要设置了 follow 的参数 rect 的 y 数值，开启 _boundarySet 进行下列的方式去设置 setPosition

```js
if (this._boundarySet) {
    // whole map fits inside a single screen, no need to modify the position - unless map boundaries are increased
    if (this._boundaryFullyCovered)
        return;
     
    this.target.setPosition(misc.clampf(tempPos.x, this.leftBoundary, this.rightBoundary), misc.clampf(tempPos.y, this.bottomBoundary, this.topBoundary));
}
```
错误效果：
![image](https://user-images.githubusercontent.com/7564028/40033772-6c5f570a-582c-11e8-899c-0803d1da5e23.png)

当前效果：
![image](https://user-images.githubusercontent.com/7564028/40033815-99f60bc8-582c-11e8-8a3b-b3db5e1a20c6.png)



