### PR TITLE
forbid user translate example-case js to es5 mode in wgplatform

### DIFF
--- a/assets/cases/05_scripting/11_network/socket-io.js
+++ b/assets/cases/05_scripting/11_network/socket-io.js
@@ -5277,6 +5277,13 @@
 
   var global = (function() { return this; })();
 
+  if (cc.sys.WECHAT_GAME) {
+    if (!global) {
+      cc.error('socket-io doesn`t support to translate to es5 mode.');
+      return;
+    }
+  }
+  
   /**
    * WebSocket constructor.
    */


### PR DESCRIPTION
Re: cocos-creator/engine#2674
添加一个判断，阻止用户在微信开发者工具将 example-case 转换为 es5 编译模式