### PR TITLE
 forbid the user to translate socket-io to ES5 mode

### DIFF
--- a/assets/cases/05_scripting/11_network/socket-io.js
+++ b/assets/cases/05_scripting/11_network/socket-io.js
@@ -5277,6 +5277,13 @@
 
   var global = (function() { return this; })();
 
+  if (cc.sys.WECHAT_GAME) {
+    if (!global) {
+      cc.error('socket-io doesn\'t support to translate to ES5 mode.');
+      return;
+    }
+  }
+  
   /**
    * WebSocket constructor.
    */


### PR DESCRIPTION
cocos-creator/engine#2674

add a new judgement that forbid the user to translate socket-io to es5 model