### PR TITLE
fix RotationAction label overflow type for fireball/issues/8005

### DIFF
--- a/assets/cases/03_gameplay/02_actions/RotationAction.fire
+++ b/assets/cases/03_gameplay/02_actions/RotationAction.fire
@@ -594,7 +594,7 @@
     },
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 100,
+      "width": 96,
       "height": 40
     },
     "_rotationX": 0,
@@ -633,7 +633,7 @@
     "_N$horizontalAlign": 1,
     "_N$verticalAlign": 1,
     "_N$fontFamily": "Arial",
-    "_N$overflow": 1
+    "_N$overflow": 0
   },
   {
     "__type__": "cc.Sprite",
@@ -897,7 +897,7 @@
     },
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 100,
+      "width": 74,
       "height": 40
     },
     "_rotationX": 0,
@@ -936,7 +936,7 @@
     "_N$horizontalAlign": 1,
     "_N$verticalAlign": 1,
     "_N$fontFamily": "Arial",
-    "_N$overflow": 1
+    "_N$overflow": 0
   },
   {
     "__type__": "cc.Sprite",
@@ -1133,7 +1133,7 @@
     },
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 100,
+      "width": 74,
       "height": 40
     },
     "_rotationX": 0,
@@ -1172,7 +1172,7 @@
     "_N$horizontalAlign": 1,
     "_N$verticalAlign": 1,
     "_N$fontFamily": "Arial",
-    "_N$overflow": 1
+    "_N$overflow": 0
   },
   {
     "__type__": "cc.Sprite",
@@ -1369,7 +1369,7 @@
     },
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 100,
+      "width": 98,
       "height": 40
     },
     "_rotationX": 0,
@@ -1408,7 +1408,7 @@
     "_N$horizontalAlign": 1,
     "_N$verticalAlign": 1,
     "_N$fontFamily": "Arial",
-    "_N$overflow": 1
+    "_N$overflow": 0
   },
   {
     "__type__": "cc.Sprite",
@@ -1605,7 +1605,7 @@
     },
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 100,
+      "width": 74,
       "height": 40
     },
     "_rotationX": 0,
@@ -1644,7 +1644,7 @@
     "_N$horizontalAlign": 1,
     "_N$verticalAlign": 1,
     "_N$fontFamily": "Arial",
-    "_N$overflow": 1
+    "_N$overflow": 0
   },
   {
     "__type__": "cc.Sprite",
@@ -1841,7 +1841,7 @@
     },
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 100,
+      "width": 74,
       "height": 40
     },
     "_rotationX": 0,
@@ -1880,7 +1880,7 @@
     "_N$horizontalAlign": 1,
     "_N$verticalAlign": 1,
     "_N$fontFamily": "Arial",
-    "_N$overflow": 1
+    "_N$overflow": 0
   },
   {
     "__type__": "cc.Sprite",


### PR DESCRIPTION
https://github.com/cocos-creator/fireball/issues/8005

修复 example-03/02->RotationAction 按钮字母被截断