### PR TITLE
correct scriptName "AdTracking" mismatch

### DIFF
--- a/assets/cases/anysdk/08_adtracking.fire
+++ b/assets/cases/anysdk/08_adtracking.fire
@@ -657,7 +657,7 @@
       "onLevelUp",
       "onStartToPay"
     ],
-    "scriptName": "AdTracking",
+    "scriptName": "Tracking",
     "_id": "50WEncYoVDi4UCGYVxVEgN"
   },
   {


### PR DESCRIPTION
for issues, https://github.com/cocos-creator/fireball/issues/8027

PR, https://github.com/cocos-creator/example-cases/pull/469 重名了脚本文件名，但是忘记更改了场景中引用的脚本名