### PR TITLE
test save render texture to file on native platform

### DIFF
--- a/assets/cases/07_render_texture/render_to_sprite.fire
+++ b/assets/cases/07_render_texture/render_to_sprite.fire
@@ -915,7 +915,7 @@
       "__id__": 2
     },
     "component": "render_to_sprite",
-    "handler": "saveToFile",
+    "handler": "saveImage",
     "customEventData": ""
   },
   {

--- a/assets/cases/07_render_texture/render_to_sprite.fire
+++ b/assets/cases/07_render_texture/render_to_sprite.fire
@@ -41,8 +41,8 @@
     },
     "_scale": {
       "__type__": "cc.Vec3",
-      "x": 0.796875,
-      "y": 0.796875,
+      "x": 0.3828125,
+      "y": 0.3828125,
       "z": 1
     },
     "_quat": {
@@ -52,7 +52,7 @@
       "z": 0,
       "w": 1
     },
-    "_localZOrder": 10,
+    "_zIndex": 0,
     "groupIndex": 0,
     "autoReleaseAssets": false,
     "_id": "162e0445-d645-4470-bc67-086eb9385618"
@@ -79,16 +79,19 @@
       },
       {
         "__id__": 13
+      },
+      {
+        "__id__": 15
       }
     ],
     "_active": true,
     "_level": 0,
     "_components": [
       {
-        "__id__": 15
+        "__id__": 21
       },
       {
-        "__id__": 16
+        "__id__": 22
       }
     ],
     "_prefab": null,
@@ -133,7 +136,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 11,
+    "_zIndex": 0,
     "groupIndex": 0,
     "_id": "a65knO45VE55L03V3lckcR"
   },
@@ -194,7 +197,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 12,
+    "_zIndex": 0,
     "groupIndex": 0,
     "_id": "acht+Rlh9O5YSJXeah1H0m"
   },
@@ -281,7 +284,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 13,
+    "_zIndex": 0,
     "groupIndex": 0,
     "_id": "5fAYCOtoBFhp7+NOuCN73E"
   },
@@ -342,7 +345,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 14,
+    "_zIndex": 0,
     "groupIndex": 0,
     "_id": "68e7IARiZCzLEQU8gjYi+x"
   },
@@ -459,7 +462,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 15,
+    "_zIndex": 0,
     "groupIndex": 0,
     "_id": "8fk7WDPmBKIL2m4iMMY2Oo"
   },
@@ -542,7 +545,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 16,
+    "_zIndex": 0,
     "groupIndex": 2,
     "_id": "5aw4DcvnJPupPVspAq+pwq"
   },
@@ -629,7 +632,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 17,
+    "_zIndex": 0,
     "groupIndex": 0,
     "_id": "8dK3OG0p9M9KHMSAVcgzSy"
   },
@@ -654,6 +657,266 @@
     "_zoomRatio": 1,
     "_targetTexture": null,
     "_id": "36YtsiUhlOP6mS27hH7qX/"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Save",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 2
+    },
+    "_children": [
+      {
+        "__id__": 16
+      }
+    ],
+    "_active": true,
+    "_level": 1,
+    "_components": [
+      {
+        "__id__": 18
+      },
+      {
+        "__id__": 19
+      }
+    ],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 100,
+      "height": 40
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0.5,
+      "y": 0.5
+    },
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": -201,
+      "y": -225,
+      "z": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_rotationX": 0,
+    "_rotationY": 0,
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_skewX": 0,
+    "_skewY": 0,
+    "_zIndex": 0,
+    "groupIndex": 0,
+    "_id": "ab0DYQ/DxOgpX70oUjRv+r"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Label",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 15
+    },
+    "_children": [],
+    "_active": true,
+    "_level": 0,
+    "_components": [
+      {
+        "__id__": 17
+      }
+    ],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 0,
+      "g": 0,
+      "b": 0,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 100,
+      "height": 40
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0.5,
+      "y": 0.5
+    },
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_rotationX": 0,
+    "_rotationY": 0,
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_skewX": 0,
+    "_skewY": 0,
+    "_zIndex": 0,
+    "groupIndex": 0,
+    "_id": "b4u6XLVq9M8qsmYPd7sHkl"
+  },
+  {
+    "__type__": "cc.Label",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 16
+    },
+    "_enabled": true,
+    "_srcBlendFactor": 1,
+    "_dstBlendFactor": 771,
+    "_useOriginalSize": false,
+    "_string": "Save",
+    "_N$string": "Save",
+    "_fontSize": 20,
+    "_lineHeight": 40,
+    "_enableWrapText": false,
+    "_N$file": null,
+    "_isSystemFontUsed": true,
+    "_spacingX": 0,
+    "_N$horizontalAlign": 1,
+    "_N$verticalAlign": 1,
+    "_N$fontFamily": "Arial",
+    "_N$overflow": 1,
+    "_id": "6b/yAH6FFDJLg3lnWnaPYG"
+  },
+  {
+    "__type__": "cc.Sprite",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 15
+    },
+    "_enabled": true,
+    "_srcBlendFactor": 770,
+    "_dstBlendFactor": 771,
+    "_spriteFrame": {
+      "__uuid__": "f0048c10-f03e-4c97-b9d3-3506e1d58952"
+    },
+    "_type": 1,
+    "_sizeMode": 0,
+    "_fillType": 0,
+    "_fillCenter": {
+      "__type__": "cc.Vec2",
+      "x": 0,
+      "y": 0
+    },
+    "_fillStart": 0,
+    "_fillRange": 0,
+    "_isTrimmedMode": true,
+    "_state": 0,
+    "_atlas": null,
+    "_id": "5fxmXHSy1CDZJQEZZpBuXF"
+  },
+  {
+    "__type__": "cc.Button",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 15
+    },
+    "_enabled": true,
+    "transition": 2,
+    "pressedColor": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "hoverColor": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "duration": 0.1,
+    "zoomScale": 1.2,
+    "clickEvents": [
+      {
+        "__id__": 20
+      }
+    ],
+    "_N$interactable": true,
+    "_N$enableAutoGrayEffect": false,
+    "_N$normalColor": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_N$disabledColor": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_N$normalSprite": {
+      "__uuid__": "f0048c10-f03e-4c97-b9d3-3506e1d58952"
+    },
+    "_N$pressedSprite": {
+      "__uuid__": "e9ec654c-97a2-4787-9325-e6a10375219a"
+    },
+    "pressedSprite": {
+      "__uuid__": "e9ec654c-97a2-4787-9325-e6a10375219a"
+    },
+    "_N$hoverSprite": {
+      "__uuid__": "f0048c10-f03e-4c97-b9d3-3506e1d58952"
+    },
+    "hoverSprite": {
+      "__uuid__": "f0048c10-f03e-4c97-b9d3-3506e1d58952"
+    },
+    "_N$disabledSprite": {
+      "__uuid__": "29158224-f8dd-4661-a796-1ffab537140e"
+    },
+    "_N$target": {
+      "__id__": 15
+    },
+    "_id": "e8raAiQtpLWYICTi2VnLhH"
+  },
+  {
+    "__type__": "cc.ClickEvent",
+    "target": {
+      "__id__": 2
+    },
+    "component": "render_to_sprite",
+    "handler": "saveToFile",
+    "customEventData": ""
   },
   {
     "__type__": "cc.Canvas",

--- a/assets/cases/07_render_texture/render_to_sprite.js
+++ b/assets/cases/07_render_texture/render_to_sprite.js
@@ -41,6 +41,7 @@ cc.Class({
     },
 
     // update (dt) {},
+
     saveToFile () {
         if (CC_JSB) {
 
@@ -51,7 +52,7 @@ cc.Class({
 
             let success = jsb.savePixelsToFile(data, width, height, filePath);
             if (success) {
-                cc.log("save  render texture success, file: " + filePath);
+                cc.log("save render texture success, file: " + filePath);
             }
             else {
                 cc.error("save render texture failed!");

--- a/assets/cases/07_render_texture/render_to_sprite.js
+++ b/assets/cases/07_render_texture/render_to_sprite.js
@@ -57,5 +57,8 @@ cc.Class({
                 cc.error("save render texture failed!");
             }
         }
+        else {
+            cc.log("save render texture to image, only supported on native platform.");
+        }
     },
 });

--- a/assets/cases/07_render_texture/render_to_sprite.js
+++ b/assets/cases/07_render_texture/render_to_sprite.js
@@ -36,7 +36,26 @@ cc.Class({
         this.sprite.spriteFrame = spriteFrame;
         
         this.camera.targetTexture = texture;
+
+        this.renderTexture = texture;
     },
 
     // update (dt) {},
+    saveToFile () {
+        if (CC_JSB) {
+
+            let data = this.renderTexture.readPixels();
+            let width = this.renderTexture.width;
+            let height = this.renderTexture.height;
+            let filePath = jsb.fileUtils.getWritablePath() + 'render_to_sprite_cocos.png';
+
+            let success = jsb.savePixelsToFile(data, width, height, filePath);
+            if (success) {
+                cc.log("save  render texture success, file: " + filePath);
+            }
+            else {
+                cc.error("save render texture failed!");
+            }
+        }
+    },
 });

--- a/assets/cases/07_render_texture/render_to_sprite.js
+++ b/assets/cases/07_render_texture/render_to_sprite.js
@@ -42,24 +42,24 @@ cc.Class({
 
     // update (dt) {},
 
-    saveToFile () {
+    saveImage () {
         if (CC_JSB) {
 
             let data = this.renderTexture.readPixels();
             let width = this.renderTexture.width;
             let height = this.renderTexture.height;
-            let filePath = jsb.fileUtils.getWritablePath() + 'render_to_sprite_cocos.png';
+            let filePath = jsb.fileUtils.getWritablePath() + 'render_to_sprite_image.png';
 
-            let success = jsb.savePixelsToFile(data, width, height, filePath);
+            let success = jsb.saveImageData(data, width, height, filePath);
             if (success) {
-                cc.log("save render texture success, file: " + filePath);
+                cc.log("save image data success, file: " + filePath);
             }
             else {
-                cc.error("save render texture failed!");
+                cc.error("save image data failed!");
             }
         }
         else {
-            cc.log("save render texture to image, only supported on native platform.");
+            cc.log("saveImage, only supported on native platform.");
         }
     },
 });

--- a/settings/creator-luacpp-support.json
+++ b/settings/creator-luacpp-support.json
@@ -1,0 +1,7 @@
+{
+  "setup": false,
+  "path": "",
+  "autoBuild": false,
+  "exportResourceOnly": false,
+  "exportResourceDynamicallyLoaded": false
+}

--- a/settings/creator-luacpp-support.json
+++ b/settings/creator-luacpp-support.json
@@ -1,7 +1,0 @@
-{
-  "setup": false,
-  "path": "",
-  "autoBuild": false,
-  "exportResourceOnly": false,
-  "exportResourceDynamicallyLoaded": false
-}


### PR DESCRIPTION
增加一个 button，用以验证保存文件到本地

保存文件的主要测试代码：

```
            let data = this.renderTexture.readPixels();
            let width = this.renderTexture.width;
            let height = this.renderTexture.height;
            let filePath = jsb.fileUtils.getWritablePath() + 'render_to_sprite_cocos.png';
             let success = jsb.savePixelsToFile(data, width, height, filePath);
            if (success) {
                cc.log("save  render texture success, file: " + filePath);
            }
```

保存后的图片：

mac 平台：

![image](https://user-images.githubusercontent.com/26329291/44904999-52e5b500-ad43-11e8-8c45-94eaa6f6add5.png)

android 平台：

<img width="846" alt="android-screenshot" src="https://user-images.githubusercontent.com/26329291/44906783-77905b80-ad48-11e8-82fe-0fcd73a9164c.png">
