### PR TITLE
modify the video fire

### DIFF
--- a/assets/cases/02_ui/09_videoplayer/VideoPlayer/VideoPlayerCtrl.js
+++ b/assets/cases/02_ui/09_videoplayer/VideoPlayer/VideoPlayerCtrl.js
@@ -1,4 +1,6 @@
 const i18n = require('i18n');
+const TipsManager = require('TipsManager');
+
 cc.Class({
     extends: cc.Component,
 
@@ -24,10 +26,9 @@ cc.Class({
             type: cc.Label
         },
         _resStatus: false,
-        _tips: null
     },
     start () {
-        this._tips = this.node.getComponent('SuspensionTips');
+        TipsManager.init();
     },
 
     play () {
@@ -45,7 +46,7 @@ cc.Class({
             cc.sys.browserVersion <= 7.2 &&
             /Nexus 6/.test(navigator.userAgent)
         ) {
-            this._tips.showTips(i18n.t('cases/02_ui/09_videoplayer/videoPlayer.nonsupport_fullscreen'));
+            TipsManager.createTips(i18n.t('cases/02_ui/09_videoplayer/videoPlayer.nonsupport_fullscreen'));
             return cc.log('May be crash, so prohibit full screen');
         }
         this.videoPlayer.isFullscreen = true;

--- a/assets/cases/02_ui/09_videoplayer/videoPlayer.fire
+++ b/assets/cases/02_ui/09_videoplayer/videoPlayer.fire
@@ -44,8 +44,8 @@
     },
     "_scale": {
       "__type__": "cc.Vec3",
-      "x": 0.6364583333333333,
-      "y": 0.6364583333333333,
+      "x": 0.5646672824164731,
+      "y": 0.5646672824164731,
       "z": 1
     },
     "_quat": {
@@ -55,7 +55,7 @@
       "z": 0,
       "w": 1
     },
-    "_localZOrder": 999,
+    "_localZOrder": 2,
     "groupIndex": 0,
     "autoReleaseAssets": true,
     "_id": "914894d0-4322-490d-ab8b-f6f39b244a77"
@@ -87,16 +87,13 @@
         "__id__": 15
       },
       {
-        "__id__": 24
+        "__id__": 30
       },
       {
         "__id__": 23
       },
       {
-        "__id__": 26
-      },
-      {
-        "__id__": 46
+        "__id__": 32
       },
       {
         "__id__": 52
@@ -106,6 +103,9 @@
       },
       {
         "__id__": 64
+      },
+      {
+        "__id__": 26
       },
       {
         "__id__": 21
@@ -160,7 +160,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1000,
+    "_localZOrder": 3,
     "groupIndex": 0,
     "_id": "a06a31K1XRMWoS6temxzSRS"
   },
@@ -221,7 +221,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1001,
+    "_localZOrder": 4,
     "groupIndex": 0,
     "_id": "96ojkPj1FMp4qYoSOKtiML"
   },
@@ -309,7 +309,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1002,
+    "_localZOrder": 5,
     "groupIndex": 0,
     "_id": "d268a2gBD9FvoXevLFLptmJ"
   },
@@ -436,7 +436,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1003,
+    "_localZOrder": 6,
     "groupIndex": 0,
     "_id": "e8bf5FtzhRDjqZN2XanJHy+"
   },
@@ -448,7 +448,7 @@
       "__id__": 9
     },
     "_enabled": true,
-    "_srcBlendFactor": 770,
+    "_srcBlendFactor": 1,
     "_dstBlendFactor": 771,
     "_useOriginalSize": false,
     "_string": "Click Video to Pause and Play",
@@ -522,7 +522,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1004,
+    "_localZOrder": 7,
     "groupIndex": 0,
     "_id": "b870dsxT8tIrpredl9FgPg5"
   },
@@ -534,7 +534,7 @@
       "__id__": 11
     },
     "_enabled": true,
-    "_srcBlendFactor": 770,
+    "_srcBlendFactor": 1,
     "_dstBlendFactor": 771,
     "_useOriginalSize": false,
     "_string": "CurrentTime:",
@@ -608,7 +608,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1005,
+    "_localZOrder": 8,
     "groupIndex": 0,
     "_id": "53e856wCy1MzodJE28Q6vNV"
   },
@@ -620,7 +620,7 @@
       "__id__": 13
     },
     "_enabled": true,
-    "_srcBlendFactor": 770,
+    "_srcBlendFactor": 1,
     "_dstBlendFactor": 771,
     "_useOriginalSize": false,
     "_string": "0",
@@ -646,7 +646,7 @@
     },
     "_children": [],
     "_active": true,
-    "_level": 0,
+    "_level": 1,
     "_components": [
       {
         "__id__": 16
@@ -663,8 +663,8 @@
     },
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 353,
-      "height": 291
+      "width": 450,
+      "height": 320
     },
     "_anchorPoint": {
       "__type__": "cc.Vec2",
@@ -673,8 +673,8 @@
     },
     "_position": {
       "__type__": "cc.Vec3",
-      "x": -24,
-      "y": -80,
+      "x": -15,
+      "y": -156,
       "z": 0
     },
     "_scale": {
@@ -694,7 +694,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1006,
+    "_localZOrder": 9,
     "groupIndex": 0,
     "_id": "efc90MUU9dJCq4nTpjQsR/K"
   },
@@ -788,7 +788,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1025,
+    "_localZOrder": 28,
     "groupIndex": 0,
     "_id": "be7dbq+rJdLG7+MM/EH0/dn"
   },
@@ -812,7 +812,10 @@
     "totalTime": {
       "__id__": 22
     },
-    "tips": null,
+    "resSwitchBtnLabel": {
+      "__id__": 24
+    },
+    "_resStatus": false,
     "_id": "5azs7T2pdAu5O8YAN5xQPM"
   },
   {
@@ -823,7 +826,7 @@
       "__id__": 21
     },
     "_enabled": true,
-    "_srcBlendFactor": 770,
+    "_srcBlendFactor": 1,
     "_dstBlendFactor": 771,
     "_useOriginalSize": false,
     "_string": 6,
@@ -897,7 +900,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1024,
+    "_localZOrder": 27,
     "groupIndex": 0,
     "_id": "04acfkGr2NAYKyyWuEr6GiJ"
   },
@@ -909,7 +912,7 @@
       "__id__": 23
     },
     "_enabled": true,
-    "_srcBlendFactor": 770,
+    "_srcBlendFactor": 1,
     "_dstBlendFactor": 771,
     "_useOriginalSize": false,
     "_string": "59.86",
@@ -983,9 +986,269 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1008,
+    "_localZOrder": 11,
     "groupIndex": 0,
     "_id": "cfc15o1JDJGPbUUykjAx8d3"
+  },
+  {
+    "__type__": "cc.Label",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 25
+    },
+    "_enabled": true,
+    "_srcBlendFactor": 1,
+    "_dstBlendFactor": 771,
+    "_useOriginalSize": false,
+    "_string": "Switch Resource To Remote",
+    "_N$string": "Switch Resource To Remote",
+    "_fontSize": 20,
+    "_lineHeight": 40,
+    "_enableWrapText": false,
+    "_N$file": null,
+    "_isSystemFontUsed": true,
+    "_spacingX": 0,
+    "_N$horizontalAlign": 1,
+    "_N$verticalAlign": 1,
+    "_N$fontFamily": "Arial",
+    "_N$overflow": 2,
+    "_id": "5fl4V1cYJLfb0l3FgEBy/2"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Label",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 26
+    },
+    "_children": [],
+    "_active": true,
+    "_level": 0,
+    "_components": [
+      {
+        "__id__": 24
+      }
+    ],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 200,
+      "height": 50
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0.5,
+      "y": 0.5
+    },
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": -1,
+      "y": 2,
+      "z": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_rotationX": 0,
+    "_rotationY": 0,
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_skewX": 0,
+    "_skewY": 0,
+    "_localZOrder": 26,
+    "groupIndex": 0,
+    "_id": "628daoRQrhG1b1cCsiFB0K+"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Video_Resource_Switch",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 2
+    },
+    "_children": [
+      {
+        "__id__": 25
+      }
+    ],
+    "_active": true,
+    "_level": 0,
+    "_components": [
+      {
+        "__id__": 27
+      },
+      {
+        "__id__": 28
+      }
+    ],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 220,
+      "height": 50
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0.5,
+      "y": 0.5
+    },
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": 353,
+      "y": -42,
+      "z": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_rotationX": 0,
+    "_rotationY": 0,
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_skewX": 0,
+    "_skewY": 0,
+    "_localZOrder": 25,
+    "groupIndex": 0,
+    "_id": "75b67so//5AoKU4KyhnvnnV"
+  },
+  {
+    "__type__": "cc.Sprite",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 26
+    },
+    "_enabled": true,
+    "_srcBlendFactor": 770,
+    "_dstBlendFactor": 771,
+    "_spriteFrame": {
+      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
+    },
+    "_type": 1,
+    "_sizeMode": 0,
+    "_fillType": 0,
+    "_fillCenter": {
+      "__type__": "cc.Vec2",
+      "x": 0,
+      "y": 0
+    },
+    "_fillStart": 0,
+    "_fillRange": 0,
+    "_isTrimmedMode": true,
+    "_state": 0,
+    "_atlas": null,
+    "_id": "c91+ucAWRLaYKvGYatsHR7"
+  },
+  {
+    "__type__": "cc.Button",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 26
+    },
+    "_enabled": true,
+    "transition": 2,
+    "pressedColor": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "hoverColor": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "duration": 0.1,
+    "zoomScale": 1.2,
+    "clickEvents": [
+      {
+        "__id__": 29
+      }
+    ],
+    "_N$interactable": true,
+    "_N$enableAutoGrayEffect": false,
+    "_N$normalColor": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_N$disabledColor": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_N$normalSprite": {
+      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
+    },
+    "_N$pressedSprite": {
+      "__uuid__": "ba9dc5f7-45ab-4ff5-be92-97c7a73b8ad5"
+    },
+    "pressedSprite": {
+      "__uuid__": "ba9dc5f7-45ab-4ff5-be92-97c7a73b8ad5"
+    },
+    "_N$hoverSprite": {
+      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
+    },
+    "hoverSprite": {
+      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
+    },
+    "_N$disabledSprite": {
+      "__uuid__": "ba9dc5f7-45ab-4ff5-be92-97c7a73b8ad5"
+    },
+    "_N$target": {
+      "__id__": 26
+    },
+    "_id": "f5V/aC4AtGwrGlP5L1pC0q"
+  },
+  {
+    "__type__": "cc.ClickEvent",
+    "target": {
+      "__id__": 18
+    },
+    "component": "VideoPlayerCtrl",
+    "handler": "playOnlineVideo",
+    "customEventData": ""
   },
   {
     "__type__": "cc.Node",
@@ -999,7 +1262,7 @@
     "_level": 0,
     "_components": [
       {
-        "__id__": 25
+        "__id__": 31
       }
     ],
     "_prefab": null,
@@ -1044,7 +1307,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1007,
+    "_localZOrder": 10,
     "groupIndex": 0,
     "_id": "d3163G04nhKO5vvcS9KWWu5"
   },
@@ -1053,10 +1316,10 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 24
+      "__id__": 30
     },
     "_enabled": true,
-    "_srcBlendFactor": 770,
+    "_srcBlendFactor": 1,
     "_dstBlendFactor": 771,
     "_useOriginalSize": false,
     "_string": "TotalTime:",
@@ -1082,20 +1345,20 @@
     },
     "_children": [
       {
-        "__id__": 27
-      },
-      {
         "__id__": 33
       },
       {
         "__id__": 39
+      },
+      {
+        "__id__": 45
       }
     ],
     "_active": true,
     "_level": 1,
     "_components": [
       {
-        "__id__": 45
+        "__id__": 51
       }
     ],
     "_prefab": null,
@@ -1140,7 +1403,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1009,
+    "_localZOrder": 12,
     "groupIndex": 0,
     "_id": "3af39UnuttD+57dGawc/GLQ"
   },
@@ -1149,21 +1412,21 @@
     "_name": "Play",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 26
+      "__id__": 32
     },
     "_children": [
       {
-        "__id__": 28
+        "__id__": 34
       }
     ],
     "_active": true,
     "_level": 0,
     "_components": [
       {
-        "__id__": 30
+        "__id__": 36
       },
       {
-        "__id__": 31
+        "__id__": 37
       }
     ],
     "_prefab": null,
@@ -1208,269 +1471,9 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1010,
+    "_localZOrder": 13,
     "groupIndex": 0,
     "_id": "e5ea07Ww9VIWLAINpCCMksz"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Label",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 27
-    },
-    "_children": [],
-    "_active": true,
-    "_level": 0,
-    "_components": [
-      {
-        "__id__": 29
-      }
-    ],
-    "_prefab": null,
-    "_opacity": 255,
-    "_color": {
-      "__type__": "cc.Color",
-      "r": 255,
-      "g": 255,
-      "b": 255,
-      "a": 255
-    },
-    "_contentSize": {
-      "__type__": "cc.Size",
-      "width": 100,
-      "height": 40
-    },
-    "_anchorPoint": {
-      "__type__": "cc.Vec2",
-      "x": 0.5,
-      "y": 0.5
-    },
-    "_position": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    },
-    "_scale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_rotationX": 0,
-    "_rotationY": 0,
-    "_quat": {
-      "__type__": "cc.Quat",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 1
-    },
-    "_skewX": 0,
-    "_skewY": 0,
-    "_localZOrder": 1011,
-    "groupIndex": 0,
-    "_id": "e35dfG/6G5KR5UMvWypeQ8t"
-  },
-  {
-    "__type__": "cc.Label",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 28
-    },
-    "_enabled": true,
-    "_srcBlendFactor": 770,
-    "_dstBlendFactor": 771,
-    "_useOriginalSize": false,
-    "_string": "Play",
-    "_N$string": "Play",
-    "_fontSize": 20,
-    "_lineHeight": 40,
-    "_enableWrapText": false,
-    "_N$file": null,
-    "_isSystemFontUsed": true,
-    "_spacingX": 0,
-    "_N$horizontalAlign": 1,
-    "_N$verticalAlign": 1,
-    "_N$fontFamily": "Arial",
-    "_N$overflow": 1,
-    "_id": "56vIba7lhB35mDd9r3xIZ6"
-  },
-  {
-    "__type__": "cc.Sprite",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 27
-    },
-    "_enabled": true,
-    "_srcBlendFactor": 770,
-    "_dstBlendFactor": 771,
-    "_spriteFrame": {
-      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
-    },
-    "_type": 1,
-    "_sizeMode": 0,
-    "_fillType": 0,
-    "_fillCenter": {
-      "__type__": "cc.Vec2",
-      "x": 0,
-      "y": 0
-    },
-    "_fillStart": 0,
-    "_fillRange": 0,
-    "_isTrimmedMode": true,
-    "_state": 0,
-    "_atlas": null,
-    "_id": "24KrgkSJtC1YsueP6mofEI"
-  },
-  {
-    "__type__": "cc.Button",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 27
-    },
-    "_enabled": true,
-    "transition": 2,
-    "pressedColor": {
-      "__type__": "cc.Color",
-      "r": 255,
-      "g": 255,
-      "b": 255,
-      "a": 255
-    },
-    "hoverColor": {
-      "__type__": "cc.Color",
-      "r": 255,
-      "g": 255,
-      "b": 255,
-      "a": 255
-    },
-    "duration": 0.1,
-    "zoomScale": 1.2,
-    "clickEvents": [
-      {
-        "__id__": 32
-      }
-    ],
-    "_N$interactable": true,
-    "_N$enableAutoGrayEffect": false,
-    "_N$normalColor": {
-      "__type__": "cc.Color",
-      "r": 255,
-      "g": 255,
-      "b": 255,
-      "a": 255
-    },
-    "_N$disabledColor": {
-      "__type__": "cc.Color",
-      "r": 255,
-      "g": 255,
-      "b": 255,
-      "a": 255
-    },
-    "_N$normalSprite": {
-      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
-    },
-    "_N$pressedSprite": {
-      "__uuid__": "ba9dc5f7-45ab-4ff5-be92-97c7a73b8ad5"
-    },
-    "pressedSprite": {
-      "__uuid__": "ba9dc5f7-45ab-4ff5-be92-97c7a73b8ad5"
-    },
-    "_N$hoverSprite": {
-      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
-    },
-    "hoverSprite": {
-      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
-    },
-    "_N$disabledSprite": {
-      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
-    },
-    "_N$target": {
-      "__id__": 27
-    },
-    "_id": "2bH8cQwJxI5Kt0YfSiw5sf"
-  },
-  {
-    "__type__": "cc.ClickEvent",
-    "target": {
-      "__id__": 18
-    },
-    "component": "VideoPlayerCtrl",
-    "handler": "play",
-    "customEventData": ""
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Pause",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 26
-    },
-    "_children": [
-      {
-        "__id__": 34
-      }
-    ],
-    "_active": true,
-    "_level": 0,
-    "_components": [
-      {
-        "__id__": 36
-      },
-      {
-        "__id__": 37
-      }
-    ],
-    "_prefab": null,
-    "_opacity": 255,
-    "_color": {
-      "__type__": "cc.Color",
-      "r": 255,
-      "g": 255,
-      "b": 255,
-      "a": 255
-    },
-    "_contentSize": {
-      "__type__": "cc.Size",
-      "width": 130,
-      "height": 50
-    },
-    "_anchorPoint": {
-      "__type__": "cc.Vec2",
-      "x": 0.5,
-      "y": 0.5
-    },
-    "_position": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    },
-    "_scale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_rotationX": 0,
-    "_rotationY": 0,
-    "_quat": {
-      "__type__": "cc.Quat",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 1
-    },
-    "_skewX": 0,
-    "_skewY": 0,
-    "_localZOrder": 1012,
-    "groupIndex": 0,
-    "_id": "7c9bbNU1tBOv5arLyXv6KrC"
   },
   {
     "__type__": "cc.Node",
@@ -1529,9 +1532,9 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1013,
+    "_localZOrder": 14,
     "groupIndex": 0,
-    "_id": "b84dbRsClBGOYpOI7gUd1t6"
+    "_id": "e35dfG/6G5KR5UMvWypeQ8t"
   },
   {
     "__type__": "cc.Label",
@@ -1541,11 +1544,11 @@
       "__id__": 34
     },
     "_enabled": true,
-    "_srcBlendFactor": 770,
+    "_srcBlendFactor": 1,
     "_dstBlendFactor": 771,
     "_useOriginalSize": false,
-    "_string": "Pause",
-    "_N$string": "Pause",
+    "_string": "Play",
+    "_N$string": "Play",
     "_fontSize": 20,
     "_lineHeight": 40,
     "_enableWrapText": false,
@@ -1556,7 +1559,7 @@
     "_N$verticalAlign": 1,
     "_N$fontFamily": "Arial",
     "_N$overflow": 1,
-    "_id": "6cyFEAm5RHPKxCqRf/1vMs"
+    "_id": "56vIba7lhB35mDd9r3xIZ6"
   },
   {
     "__type__": "cc.Sprite",
@@ -1584,7 +1587,7 @@
     "_isTrimmedMode": true,
     "_state": 0,
     "_atlas": null,
-    "_id": "e1wX8BQ+FAeY4ZwPnbolsR"
+    "_id": "24KrgkSJtC1YsueP6mofEI"
   },
   {
     "__type__": "cc.Button",
@@ -1648,12 +1651,12 @@
       "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
     },
     "_N$disabledSprite": {
-      "__uuid__": "ba9dc5f7-45ab-4ff5-be92-97c7a73b8ad5"
+      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
     },
     "_N$target": {
       "__id__": 33
     },
-    "_id": "b3h+VLLYJJxLEZLiFBcMvM"
+    "_id": "2bH8cQwJxI5Kt0YfSiw5sf"
   },
   {
     "__type__": "cc.ClickEvent",
@@ -1661,15 +1664,15 @@
       "__id__": 18
     },
     "component": "VideoPlayerCtrl",
-    "handler": "pause",
+    "handler": "play",
     "customEventData": ""
   },
   {
     "__type__": "cc.Node",
-    "_name": "Stop",
+    "_name": "Pause",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 26
+      "__id__": 32
     },
     "_children": [
       {
@@ -1707,7 +1710,7 @@
     },
     "_position": {
       "__type__": "cc.Vec3",
-      "x": 158,
+      "x": 0,
       "y": 0,
       "z": 0
     },
@@ -1728,9 +1731,9 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1014,
+    "_localZOrder": 15,
     "groupIndex": 0,
-    "_id": "cd633rIN0RCNpLmiKRjHh66"
+    "_id": "7c9bbNU1tBOv5arLyXv6KrC"
   },
   {
     "__type__": "cc.Node",
@@ -1789,9 +1792,9 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1015,
+    "_localZOrder": 16,
     "groupIndex": 0,
-    "_id": "c187dodXZxGhqTILSGmGv2W"
+    "_id": "b84dbRsClBGOYpOI7gUd1t6"
   },
   {
     "__type__": "cc.Label",
@@ -1801,11 +1804,11 @@
       "__id__": 40
     },
     "_enabled": true,
-    "_srcBlendFactor": 770,
+    "_srcBlendFactor": 1,
     "_dstBlendFactor": 771,
     "_useOriginalSize": false,
-    "_string": "Stop",
-    "_N$string": "Stop",
+    "_string": "Pause",
+    "_N$string": "Pause",
     "_fontSize": 20,
     "_lineHeight": 40,
     "_enableWrapText": false,
@@ -1816,7 +1819,7 @@
     "_N$verticalAlign": 1,
     "_N$fontFamily": "Arial",
     "_N$overflow": 1,
-    "_id": "fcoaxr8dRLEInzgSJazw8+"
+    "_id": "6cyFEAm5RHPKxCqRf/1vMs"
   },
   {
     "__type__": "cc.Sprite",
@@ -1844,7 +1847,7 @@
     "_isTrimmedMode": true,
     "_state": 0,
     "_atlas": null,
-    "_id": "78e19Pb6BHpInAZ5Qwb3Yr"
+    "_id": "e1wX8BQ+FAeY4ZwPnbolsR"
   },
   {
     "__type__": "cc.Button",
@@ -1913,6 +1916,266 @@
     "_N$target": {
       "__id__": 39
     },
+    "_id": "b3h+VLLYJJxLEZLiFBcMvM"
+  },
+  {
+    "__type__": "cc.ClickEvent",
+    "target": {
+      "__id__": 18
+    },
+    "component": "VideoPlayerCtrl",
+    "handler": "pause",
+    "customEventData": ""
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Stop",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 32
+    },
+    "_children": [
+      {
+        "__id__": 46
+      }
+    ],
+    "_active": true,
+    "_level": 0,
+    "_components": [
+      {
+        "__id__": 48
+      },
+      {
+        "__id__": 49
+      }
+    ],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 130,
+      "height": 50
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0.5,
+      "y": 0.5
+    },
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": 158,
+      "y": 0,
+      "z": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_rotationX": 0,
+    "_rotationY": 0,
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_skewX": 0,
+    "_skewY": 0,
+    "_localZOrder": 17,
+    "groupIndex": 0,
+    "_id": "cd633rIN0RCNpLmiKRjHh66"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Label",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 45
+    },
+    "_children": [],
+    "_active": true,
+    "_level": 0,
+    "_components": [
+      {
+        "__id__": 47
+      }
+    ],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 100,
+      "height": 40
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0.5,
+      "y": 0.5
+    },
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_rotationX": 0,
+    "_rotationY": 0,
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_skewX": 0,
+    "_skewY": 0,
+    "_localZOrder": 18,
+    "groupIndex": 0,
+    "_id": "c187dodXZxGhqTILSGmGv2W"
+  },
+  {
+    "__type__": "cc.Label",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 46
+    },
+    "_enabled": true,
+    "_srcBlendFactor": 1,
+    "_dstBlendFactor": 771,
+    "_useOriginalSize": false,
+    "_string": "Stop",
+    "_N$string": "Stop",
+    "_fontSize": 20,
+    "_lineHeight": 40,
+    "_enableWrapText": false,
+    "_N$file": null,
+    "_isSystemFontUsed": true,
+    "_spacingX": 0,
+    "_N$horizontalAlign": 1,
+    "_N$verticalAlign": 1,
+    "_N$fontFamily": "Arial",
+    "_N$overflow": 1,
+    "_id": "fcoaxr8dRLEInzgSJazw8+"
+  },
+  {
+    "__type__": "cc.Sprite",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 45
+    },
+    "_enabled": true,
+    "_srcBlendFactor": 770,
+    "_dstBlendFactor": 771,
+    "_spriteFrame": {
+      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
+    },
+    "_type": 1,
+    "_sizeMode": 0,
+    "_fillType": 0,
+    "_fillCenter": {
+      "__type__": "cc.Vec2",
+      "x": 0,
+      "y": 0
+    },
+    "_fillStart": 0,
+    "_fillRange": 0,
+    "_isTrimmedMode": true,
+    "_state": 0,
+    "_atlas": null,
+    "_id": "78e19Pb6BHpInAZ5Qwb3Yr"
+  },
+  {
+    "__type__": "cc.Button",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 45
+    },
+    "_enabled": true,
+    "transition": 2,
+    "pressedColor": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "hoverColor": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "duration": 0.1,
+    "zoomScale": 1.2,
+    "clickEvents": [
+      {
+        "__id__": 50
+      }
+    ],
+    "_N$interactable": true,
+    "_N$enableAutoGrayEffect": false,
+    "_N$normalColor": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_N$disabledColor": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_N$normalSprite": {
+      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
+    },
+    "_N$pressedSprite": {
+      "__uuid__": "ba9dc5f7-45ab-4ff5-be92-97c7a73b8ad5"
+    },
+    "pressedSprite": {
+      "__uuid__": "ba9dc5f7-45ab-4ff5-be92-97c7a73b8ad5"
+    },
+    "_N$hoverSprite": {
+      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
+    },
+    "hoverSprite": {
+      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
+    },
+    "_N$disabledSprite": {
+      "__uuid__": "ba9dc5f7-45ab-4ff5-be92-97c7a73b8ad5"
+    },
+    "_N$target": {
+      "__id__": 45
+    },
     "_id": "00rlFo11xAopiI/mNdr6qk"
   },
   {
@@ -1929,7 +2192,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 26
+      "__id__": 32
     },
     "_enabled": true,
     "_layoutSize": {
@@ -1965,17 +2228,17 @@
     },
     "_children": [
       {
-        "__id__": 47
+        "__id__": 53
       }
     ],
     "_active": true,
     "_level": 0,
     "_components": [
       {
-        "__id__": 49
+        "__id__": 55
       },
       {
-        "__id__": 50
+        "__id__": 56
       }
     ],
     "_prefab": null,
@@ -2020,7 +2283,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1016,
+    "_localZOrder": 19,
     "groupIndex": 0,
     "_id": "f2d05n/KaxKrrBn9MA5ZcD3"
   },
@@ -2029,14 +2292,14 @@
     "_name": "Label",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 46
+      "__id__": 52
     },
     "_children": [],
     "_active": true,
     "_level": 0,
     "_components": [
       {
-        "__id__": 48
+        "__id__": 54
       }
     ],
     "_prefab": null,
@@ -2081,7 +2344,7 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1017,
+    "_localZOrder": 20,
     "groupIndex": 0,
     "_id": "76331VSiqZAz4Bo8gPptU2g"
   },
@@ -2090,10 +2353,10 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 47
+      "__id__": 53
     },
     "_enabled": true,
-    "_srcBlendFactor": 770,
+    "_srcBlendFactor": 1,
     "_dstBlendFactor": 771,
     "_useOriginalSize": false,
     "_string": "Visibility",
@@ -2115,7 +2378,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 46
+      "__id__": 52
     },
     "_enabled": true,
     "_srcBlendFactor": 770,
@@ -2137,266 +2400,6 @@
     "_state": 0,
     "_atlas": null,
     "_id": "d1IoXID9JKlrkgN1Hdi4dW"
-  },
-  {
-    "__type__": "cc.Button",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 46
-    },
-    "_enabled": true,
-    "transition": 2,
-    "pressedColor": {
-      "__type__": "cc.Color",
-      "r": 255,
-      "g": 255,
-      "b": 255,
-      "a": 255
-    },
-    "hoverColor": {
-      "__type__": "cc.Color",
-      "r": 255,
-      "g": 255,
-      "b": 255,
-      "a": 255
-    },
-    "duration": 0.1,
-    "zoomScale": 1.2,
-    "clickEvents": [
-      {
-        "__id__": 51
-      }
-    ],
-    "_N$interactable": true,
-    "_N$enableAutoGrayEffect": false,
-    "_N$normalColor": {
-      "__type__": "cc.Color",
-      "r": 255,
-      "g": 255,
-      "b": 255,
-      "a": 255
-    },
-    "_N$disabledColor": {
-      "__type__": "cc.Color",
-      "r": 255,
-      "g": 255,
-      "b": 255,
-      "a": 255
-    },
-    "_N$normalSprite": {
-      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
-    },
-    "_N$pressedSprite": {
-      "__uuid__": "ba9dc5f7-45ab-4ff5-be92-97c7a73b8ad5"
-    },
-    "pressedSprite": {
-      "__uuid__": "ba9dc5f7-45ab-4ff5-be92-97c7a73b8ad5"
-    },
-    "_N$hoverSprite": {
-      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
-    },
-    "hoverSprite": {
-      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
-    },
-    "_N$disabledSprite": {
-      "__uuid__": "ba9dc5f7-45ab-4ff5-be92-97c7a73b8ad5"
-    },
-    "_N$target": {
-      "__id__": 46
-    },
-    "_id": "9ajJ7atCZF5bjHO8ScJPxh"
-  },
-  {
-    "__type__": "cc.ClickEvent",
-    "target": {
-      "__id__": 18
-    },
-    "component": "VideoPlayerCtrl",
-    "handler": "toggleVisibility",
-    "customEventData": ""
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Toggle_Fullscreen",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 2
-    },
-    "_children": [
-      {
-        "__id__": 53
-      }
-    ],
-    "_active": true,
-    "_level": 0,
-    "_components": [
-      {
-        "__id__": 55
-      },
-      {
-        "__id__": 56
-      }
-    ],
-    "_prefab": null,
-    "_opacity": 255,
-    "_color": {
-      "__type__": "cc.Color",
-      "r": 255,
-      "g": 255,
-      "b": 255,
-      "a": 255
-    },
-    "_contentSize": {
-      "__type__": "cc.Size",
-      "width": 150,
-      "height": 50
-    },
-    "_anchorPoint": {
-      "__type__": "cc.Vec2",
-      "x": 0.5,
-      "y": 0.5
-    },
-    "_position": {
-      "__type__": "cc.Vec3",
-      "x": -361,
-      "y": -43,
-      "z": 0
-    },
-    "_scale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_rotationX": 0,
-    "_rotationY": 0,
-    "_quat": {
-      "__type__": "cc.Quat",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 1
-    },
-    "_skewX": 0,
-    "_skewY": 0,
-    "_localZOrder": 1018,
-    "groupIndex": 0,
-    "_id": "057deSIb5lOjJ/oDw49x3My"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Label",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 52
-    },
-    "_children": [],
-    "_active": true,
-    "_level": 0,
-    "_components": [
-      {
-        "__id__": 54
-      }
-    ],
-    "_prefab": null,
-    "_opacity": 255,
-    "_color": {
-      "__type__": "cc.Color",
-      "r": 255,
-      "g": 255,
-      "b": 255,
-      "a": 255
-    },
-    "_contentSize": {
-      "__type__": "cc.Size",
-      "width": 150,
-      "height": 50
-    },
-    "_anchorPoint": {
-      "__type__": "cc.Vec2",
-      "x": 0.5,
-      "y": 0.5
-    },
-    "_position": {
-      "__type__": "cc.Vec3",
-      "x": -1,
-      "y": 2,
-      "z": 0
-    },
-    "_scale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_rotationX": 0,
-    "_rotationY": 0,
-    "_quat": {
-      "__type__": "cc.Quat",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 1
-    },
-    "_skewX": 0,
-    "_skewY": 0,
-    "_localZOrder": 1019,
-    "groupIndex": 0,
-    "_id": "a49bbHaLIlKqrJExXcfdIiM"
-  },
-  {
-    "__type__": "cc.Label",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 53
-    },
-    "_enabled": true,
-    "_srcBlendFactor": 770,
-    "_dstBlendFactor": 771,
-    "_useOriginalSize": false,
-    "_string": "Fullscreen",
-    "_N$string": "Fullscreen",
-    "_fontSize": 20,
-    "_lineHeight": 40,
-    "_enableWrapText": false,
-    "_N$file": null,
-    "_isSystemFontUsed": true,
-    "_spacingX": 0,
-    "_N$horizontalAlign": 1,
-    "_N$verticalAlign": 1,
-    "_N$fontFamily": "Arial",
-    "_N$overflow": 2,
-    "_id": "4a1RP/qgJHdY4PlkBkJAjr"
-  },
-  {
-    "__type__": "cc.Sprite",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 52
-    },
-    "_enabled": true,
-    "_srcBlendFactor": 770,
-    "_dstBlendFactor": 771,
-    "_spriteFrame": {
-      "__uuid__": "cb79e92b-2b6b-4445-91cc-6276f7496ddc"
-    },
-    "_type": 1,
-    "_sizeMode": 0,
-    "_fillType": 0,
-    "_fillCenter": {
-      "__type__": "cc.Vec2",
-      "x": 0,
-      "y": 0
-    },
-    "_fillStart": 0,
-    "_fillRange": 0,
-    "_isTrimmedMode": true,
-    "_state": 0,
-    "_atlas": null,
-    "_id": "5dk1iwpONCJIxKEO3qHOkj"
   },
   {
     "__type__": "cc.Button",
@@ -2465,7 +2468,7 @@
     "_N$target": {
       "__id__": 52
     },
-    "_id": "5b4V8B1IhLSJNCsr4pI2DL"
+    "_id": "9ajJ7atCZF5bjHO8ScJPxh"
   },
   {
     "__type__": "cc.ClickEvent",
@@ -2473,12 +2476,12 @@
       "__id__": 18
     },
     "component": "VideoPlayerCtrl",
-    "handler": "toggleFullscreen",
+    "handler": "toggleVisibility",
     "customEventData": ""
   },
   {
     "__type__": "cc.Node",
-    "_name": "Keep_Ratio_Switch",
+    "_name": "Toggle_Fullscreen",
     "_objFlags": 0,
     "_parent": {
       "__id__": 2
@@ -2509,7 +2512,7 @@
     },
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 190,
+      "width": 150,
       "height": 50
     },
     "_anchorPoint": {
@@ -2519,8 +2522,8 @@
     },
     "_position": {
       "__type__": "cc.Vec3",
-      "x": 349,
-      "y": 63,
+      "x": -361,
+      "y": -43,
       "z": 0
     },
     "_scale": {
@@ -2540,9 +2543,9 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1020,
+    "_localZOrder": 21,
     "groupIndex": 0,
-    "_id": "920fcd2mlhBTLaaumZGR/wW"
+    "_id": "057deSIb5lOjJ/oDw49x3My"
   },
   {
     "__type__": "cc.Node",
@@ -2570,8 +2573,8 @@
     },
     "_contentSize": {
       "__type__": "cc.Size",
-      "width": 190,
-      "height": 40
+      "width": 150,
+      "height": 50
     },
     "_anchorPoint": {
       "__type__": "cc.Vec2",
@@ -2601,9 +2604,9 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1021,
+    "_localZOrder": 22,
     "groupIndex": 0,
-    "_id": "e3a2cMyre9MGprGBA/aPf4Q"
+    "_id": "a49bbHaLIlKqrJExXcfdIiM"
   },
   {
     "__type__": "cc.Label",
@@ -2613,11 +2616,11 @@
       "__id__": 59
     },
     "_enabled": true,
-    "_srcBlendFactor": 770,
+    "_srcBlendFactor": 1,
     "_dstBlendFactor": 771,
     "_useOriginalSize": false,
-    "_string": "Keep Ratio Switch",
-    "_N$string": "Keep Ratio Switch",
+    "_string": "Fullscreen",
+    "_N$string": "Fullscreen",
     "_fontSize": 20,
     "_lineHeight": 40,
     "_enableWrapText": false,
@@ -2628,7 +2631,7 @@
     "_N$verticalAlign": 1,
     "_N$fontFamily": "Arial",
     "_N$overflow": 2,
-    "_id": "daGvOUQFZHdIBElM8g/vKa"
+    "_id": "4a1RP/qgJHdY4PlkBkJAjr"
   },
   {
     "__type__": "cc.Sprite",
@@ -2656,7 +2659,7 @@
     "_isTrimmedMode": true,
     "_state": 0,
     "_atlas": null,
-    "_id": "4fOBIDwZJBgbczTcs0/HLK"
+    "_id": "5dk1iwpONCJIxKEO3qHOkj"
   },
   {
     "__type__": "cc.Button",
@@ -2725,7 +2728,7 @@
     "_N$target": {
       "__id__": 58
     },
-    "_id": "7cnN4kJJtJ5I/PsMbQQSgB"
+    "_id": "5b4V8B1IhLSJNCsr4pI2DL"
   },
   {
     "__type__": "cc.ClickEvent",
@@ -2733,12 +2736,12 @@
       "__id__": 18
     },
     "component": "VideoPlayerCtrl",
-    "handler": "keepRatioSwitch",
+    "handler": "toggleFullscreen",
     "customEventData": ""
   },
   {
     "__type__": "cc.Node",
-    "_name": "Play_Online_Video",
+    "_name": "Keep_Ratio_Switch",
     "_objFlags": 0,
     "_parent": {
       "__id__": 2
@@ -2779,8 +2782,8 @@
     },
     "_position": {
       "__type__": "cc.Vec3",
-      "x": 353,
-      "y": -42,
+      "x": 349,
+      "y": 63,
       "z": 0
     },
     "_scale": {
@@ -2800,9 +2803,9 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1022,
+    "_localZOrder": 23,
     "groupIndex": 0,
-    "_id": "75b67so//5AoKU4KyhnvnnV"
+    "_id": "920fcd2mlhBTLaaumZGR/wW"
   },
   {
     "__type__": "cc.Node",
@@ -2831,7 +2834,7 @@
     "_contentSize": {
       "__type__": "cc.Size",
       "width": 190,
-      "height": 50
+      "height": 40
     },
     "_anchorPoint": {
       "__type__": "cc.Vec2",
@@ -2861,9 +2864,9 @@
     },
     "_skewX": 0,
     "_skewY": 0,
-    "_localZOrder": 1023,
+    "_localZOrder": 24,
     "groupIndex": 0,
-    "_id": "628daoRQrhG1b1cCsiFB0K+"
+    "_id": "e3a2cMyre9MGprGBA/aPf4Q"
   },
   {
     "__type__": "cc.Label",
@@ -2873,11 +2876,11 @@
       "__id__": 65
     },
     "_enabled": true,
-    "_srcBlendFactor": 770,
+    "_srcBlendFactor": 1,
     "_dstBlendFactor": 771,
     "_useOriginalSize": false,
-    "_string": "Play Online Video",
-    "_N$string": "Play Online Video",
+    "_string": "Keep Ratio Switch",
+    "_N$string": "Keep Ratio Switch",
     "_fontSize": 20,
     "_lineHeight": 40,
     "_enableWrapText": false,
@@ -2888,7 +2891,7 @@
     "_N$verticalAlign": 1,
     "_N$fontFamily": "Arial",
     "_N$overflow": 2,
-    "_id": "5fl4V1cYJLfb0l3FgEBy/2"
+    "_id": "daGvOUQFZHdIBElM8g/vKa"
   },
   {
     "__type__": "cc.Sprite",
@@ -2916,7 +2919,7 @@
     "_isTrimmedMode": true,
     "_state": 0,
     "_atlas": null,
-    "_id": "c91+ucAWRLaYKvGYatsHR7"
+    "_id": "4fOBIDwZJBgbczTcs0/HLK"
   },
   {
     "__type__": "cc.Button",
@@ -2985,7 +2988,7 @@
     "_N$target": {
       "__id__": 64
     },
-    "_id": "f5V/aC4AtGwrGlP5L1pC0q"
+    "_id": "7cnN4kJJtJ5I/PsMbQQSgB"
   },
   {
     "__type__": "cc.ClickEvent",
@@ -2993,7 +2996,7 @@
       "__id__": 18
     },
     "component": "VideoPlayerCtrl",
-    "handler": "playOnlineVideo",
+    "handler": "keepRatioSwitch",
     "customEventData": ""
   },
   {

--- a/assets/i18n/data/en.js
+++ b/assets/i18n/data/en.js
@@ -136,6 +136,7 @@ module.exports = {
     "cases/02_ui/07_editBox/EditBox.fire.38": "Button must be on top of EditBox, \nand it should enable click.",
 
     "cases/02_ui/09_videoplayer/fullscreenVideo.fire": "When you touch the screen, video will be played. \n It will be removed when video complete.",
+    "cases/02_ui/09_videoplayer/videoPlayer.nonsupport_fullscreen": "currect device does nonsupport fullscreen.",
 
     "cases/03_gameplay/01_player_control/EventManager/KeyboardInput.fire.6": "Press 'A' or 'D' to control sheep",
     "cases/03_gameplay/01_player_control/On/OnTouchCtrl.js.1": "touch (",

--- a/assets/i18n/data/zh.js
+++ b/assets/i18n/data/zh.js
@@ -137,6 +137,7 @@ module.exports = {
     "cases/02_ui/07_editBox/EditBox.fire.38": "按钮必须在 EditBox 的上面, \n并且它应该允许点击.",
 
     "cases/02_ui/09_videoplayer/fullscreenVideo.fire": "当您触摸屏幕时，将播放视频。\n 视频完成后，它将被删除。",
+    "cases/02_ui/09_videoplayer/videoPlayer.nonsupport_fullscreen": "当前设备不支持全屏播放",
 
     "cases/03_gameplay/01_player_control/EventManager/KeyboardInput.fire.6": "按 'A' 或 'D' 键控制小绵羊",
     "cases/03_gameplay/01_player_control/On/OnTouchCtrl.js.1": "touch (",


### PR DESCRIPTION
Re: https://github.com/cocos-creator/example-cases/issues/553
 修改场景内容：

1.修改了资源远程本地的切换按钮
2. 增加了一条文本提示。
预览正常
模拟器不支持这个场景
手机构建 web 正常显示.

2. 存在问题： 由于使用了 2.0 的 TipsManager 创建提示信息， video 居中放置会导致文本显示被 videoPlay 给覆盖住，所以我将它下移了一部分距离，给 Tips 留下足够的空间用于显示信息。不是特别好看。
![image](https://user-images.githubusercontent.com/35832931/45025449-1af5af00-b06e-11e8-8fc3-303245ced27e.png)

