### PR TITLE
update editBoxEvent scene

### DIFF
--- a/assets/cases/02_ui/08_editBox/EditBox/EditBoxEvent.js
+++ b/assets/cases/02_ui/08_editBox/EditBox/EditBoxEvent.js
@@ -5,12 +5,15 @@ cc.Class({
         editBox: cc.EditBox,
         stayOnTop: cc.Toggle,
         eventDisplay: cc.Label,
+        platfromTip: cc.Node,
 
         _isEditingReturn: false,
     },
 
     start () {
         this.editBox.stayOnTop = this.stayOnTop.isChecked;
+        this.stayOnTop.node.active = cc.sys.isBrowser;
+        this.platfromTip.active = !cc.sys.isBrowser;
     },
 
     onStayOnTop (event) {

--- a/assets/cases/02_ui/08_editBox/EditBoxEvent.fire
+++ b/assets/cases/02_ui/08_editBox/EditBoxEvent.fire
@@ -41,8 +41,8 @@
     },
     "_scale": {
       "__type__": "cc.Vec3",
-      "x": 0.7968505859375,
-      "y": 0.7968505859375,
+      "x": 0.39218750000000413,
+      "y": 0.39218750000000413,
       "z": 1
     },
     "_quat": {
@@ -78,17 +78,20 @@
         "__id__": 21
       },
       {
-        "__id__": 32
+        "__id__": 23
+      },
+      {
+        "__id__": 34
       }
     ],
     "_active": true,
     "_level": 0,
     "_components": [
       {
-        "__id__": 35
+        "__id__": 37
       },
       {
-        "__id__": 36
+        "__id__": 38
       }
     ],
     "_prefab": null,
@@ -798,6 +801,92 @@
   },
   {
     "__type__": "cc.Node",
+    "_name": "platformTip",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 2
+    },
+    "_children": [],
+    "_active": false,
+    "_level": 1,
+    "_components": [
+      {
+        "__id__": 22
+      }
+    ],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 165,
+      "g": 162,
+      "b": 162,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 395.1,
+      "height": 40
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0.5,
+      "y": 0.5
+    },
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": 24,
+      "y": 17,
+      "z": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_rotationX": 0,
+    "_rotationY": 0,
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_skewX": 0,
+    "_skewY": 0,
+    "_zIndex": 0,
+    "groupIndex": 0,
+    "_id": "f7DHP4obtA2JczUaz5H96K"
+  },
+  {
+    "__type__": "cc.Label",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 21
+    },
+    "_enabled": true,
+    "_srcBlendFactor": 1,
+    "_dstBlendFactor": 771,
+    "_useOriginalSize": false,
+    "_string": "该平台不支持设置 stay on top",
+    "_N$string": "该平台不支持设置 stay on top",
+    "_fontSize": 30,
+    "_lineHeight": 40,
+    "_enableWrapText": true,
+    "_N$file": null,
+    "_isSystemFontUsed": true,
+    "_spacingX": 0,
+    "_N$horizontalAlign": 1,
+    "_N$verticalAlign": 1,
+    "_N$fontFamily": "Arial",
+    "_N$overflow": 0,
+    "_id": "e091ejU7tImraGBTgIyn5+"
+  },
+  {
+    "__type__": "cc.Node",
     "_name": "stayOnTop",
     "_objFlags": 0,
     "_parent": {
@@ -805,23 +894,23 @@
     },
     "_children": [
       {
-        "__id__": 22
+        "__id__": 24
       },
       {
-        "__id__": 26
+        "__id__": 28
       }
     ],
     "_active": true,
     "_level": 1,
     "_components": [
       {
-        "__id__": 28
-      },
-      {
-        "__id__": 29
+        "__id__": 30
       },
       {
         "__id__": 31
+      },
+      {
+        "__id__": 33
       }
     ],
     "_prefab": null,
@@ -875,18 +964,18 @@
     "_name": "Background",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 21
+      "__id__": 23
     },
     "_children": [
       {
-        "__id__": 23
+        "__id__": 25
       }
     ],
     "_active": true,
     "_level": 0,
     "_components": [
       {
-        "__id__": 25
+        "__id__": 27
       }
     ],
     "_prefab": null,
@@ -940,14 +1029,14 @@
     "_name": "checkmark",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 22
+      "__id__": 24
     },
     "_children": [],
     "_active": false,
     "_level": 1,
     "_components": [
       {
-        "__id__": 24
+        "__id__": 26
       }
     ],
     "_prefab": null,
@@ -1001,7 +1090,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 23
+      "__id__": 25
     },
     "_enabled": true,
     "_srcBlendFactor": 770,
@@ -1029,7 +1118,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 22
+      "__id__": 24
     },
     "_enabled": true,
     "_srcBlendFactor": 770,
@@ -1057,14 +1146,14 @@
     "_name": "New Label",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 21
+      "__id__": 23
     },
     "_children": [],
     "_active": true,
     "_level": 2,
     "_components": [
       {
-        "__id__": 27
+        "__id__": 29
       }
     ],
     "_prefab": null,
@@ -1118,7 +1207,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 26
+      "__id__": 28
     },
     "_enabled": true,
     "_srcBlendFactor": 1,
@@ -1143,7 +1232,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 21
+      "__id__": 23
     },
     "_enabled": true,
     "_layoutSize": {
@@ -1175,7 +1264,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 21
+      "__id__": 23
     },
     "_enabled": true,
     "transition": 3,
@@ -1219,15 +1308,15 @@
     "hoverSprite": null,
     "_N$disabledSprite": null,
     "_N$target": {
-      "__id__": 22
+      "__id__": 24
     },
     "toggleGroup": null,
     "checkMark": {
-      "__id__": 24
+      "__id__": 26
     },
     "checkEvents": [
       {
-        "__id__": 30
+        "__id__": 32
       }
     ],
     "_N$isChecked": false,
@@ -1247,7 +1336,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 21
+      "__id__": 23
     },
     "_enabled": true,
     "alignMode": 1,
@@ -1281,10 +1370,10 @@
     "_level": 1,
     "_components": [
       {
-        "__id__": 33
+        "__id__": 35
       },
       {
-        "__id__": 34
+        "__id__": 36
       }
     ],
     "_prefab": null,
@@ -1309,7 +1398,7 @@
     "_position": {
       "__type__": "cc.Vec3",
       "x": 0,
-      "y": -90,
+      "y": 157,
       "z": 0
     },
     "_scale": {
@@ -1338,7 +1427,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 32
+      "__id__": 34
     },
     "_enabled": true,
     "_srcBlendFactor": 1,
@@ -1363,7 +1452,7 @@
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 32
+      "__id__": 34
     },
     "_enabled": true,
     "alignMode": 1,
@@ -1414,10 +1503,13 @@
       "__id__": 15
     },
     "stayOnTop": {
-      "__id__": 29
+      "__id__": 31
     },
     "eventDisplay": {
-      "__id__": 33
+      "__id__": 35
+    },
+    "platfromTip": {
+      "__id__": 21
     },
     "_isEditingReturn": false,
     "_id": "71JWB59iFL74yyNrnTVLkM"


### PR DESCRIPTION
Re: 
https://github.com/cocos-creator/fireball/issues/8348
https://github.com/cocos-creator/fireball/issues/8338

- 重新调整 editBoxEvent 布局，避免移动端测试 label 被键盘挡住
- 在不支持的平台禁用 stayOnTop 选项, 只有 web 平台支持 stayOnTop

<img width="557" alt="2018-09-06 2 20 06" src="https://user-images.githubusercontent.com/17872773/45138759-384a8a80-b1e0-11e8-86d8-10c04092b432.png">

![wechatimg9](https://user-images.githubusercontent.com/17872773/45138673-ddb12e80-b1df-11e8-9e86-c299061d5792.jpeg)
