### PR TITLE
fixed the dragonBone load error

### DIFF
--- a/assets/cases/dragonbones/loadDragonBones/loadDragonBonesCtrl.js
+++ b/assets/cases/dragonbones/loadDragonBones/loadDragonBonesCtrl.js
@@ -5,10 +5,13 @@ cc.Class({
         dragonBone: {
             default: null,
             type: dragonBones.ArmatureDisplay
-        }   
+        }
     },
 
     dynamicCreate () {
+        if (this.dragonBone.dragonAtlasAsset) {
+            return;
+        }
         cc.loader.loadRes('dragonBones/NewDragonTest', dragonBones.DragonBonesAsset, (err, res) => {
             if (err) cc.error(err);
             this.dragonBone.dragonAsset = res;


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/458

1. 避免动态加载资源过程中用户切换场景导致报错。保姆式编程的罪过。。。。
