### PR TITLE
add a scene to get the ios safeArea

### DIFF
--- a/assets/TestList.fire
+++ b/assets/TestList.fire
@@ -4034,7 +4034,7 @@
   },
   {
     "__type__": "cc.Node",
-    "_name": "Bottom Menu",
+    "_name": "Center Menu",
     "_objFlags": 0,
     "_parent": {
       "__id__": 45

--- a/assets/cases/02_ui/16_safeArea.meta
+++ b/assets/cases/02_ui/16_safeArea.meta
@@ -1,0 +1,7 @@
+{
+  "ver": "1.0.1",
+  "uuid": "85905089-23e0-4971-98ff-a65ca28e25b6",
+  "isSubpackage": false,
+  "subpackageName": "",
+  "subMetas": {}
+}

--- a/assets/cases/02_ui/16_safeArea/IOS_SafeArea.fire
+++ b/assets/cases/02_ui/16_safeArea/IOS_SafeArea.fire
@@ -1,0 +1,523 @@
+[
+  {
+    "__type__": "cc.SceneAsset",
+    "_name": "",
+    "_objFlags": 0,
+    "_native": "",
+    "scene": {
+      "__id__": 1
+    }
+  },
+  {
+    "__type__": "cc.Scene",
+    "_objFlags": 0,
+    "_parent": null,
+    "_children": [
+      {
+        "__id__": 2
+      },
+      {
+        "__id__": 12
+      }
+    ],
+    "_active": true,
+    "_level": 0,
+    "_components": [],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 0,
+      "height": 0
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0,
+      "y": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 0.715625,
+      "y": 0.715625,
+      "z": 1
+    },
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_zIndex": 0,
+    "groupIndex": 0,
+    "autoReleaseAssets": false,
+    "_id": "a2968b9d-92ff-4e69-9687-1710460078be"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Canvas",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 1
+    },
+    "_children": [
+      {
+        "__id__": 3
+      },
+      {
+        "__id__": 5
+      },
+      {
+        "__id__": 7
+      },
+      {
+        "__id__": 9
+      }
+    ],
+    "_active": true,
+    "_level": 0,
+    "_components": [
+      {
+        "__id__": 11
+      }
+    ],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 960,
+      "height": 640
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0.5,
+      "y": 0.5
+    },
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": 480,
+      "y": 320,
+      "z": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_rotationX": 0,
+    "_rotationY": 0,
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_skewX": 0,
+    "_skewY": 0,
+    "_zIndex": 0,
+    "groupIndex": 0,
+    "_id": "17Gqhl/MxITLS0gKZYtT+L"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Main Camera",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 2
+    },
+    "_children": [],
+    "_active": true,
+    "_level": 1,
+    "_components": [
+      {
+        "__id__": 4
+      }
+    ],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 0,
+      "height": 0
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0.5,
+      "y": 0.5
+    },
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_rotationX": 0,
+    "_rotationY": 0,
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_skewX": 0,
+    "_skewY": 0,
+    "_zIndex": 0,
+    "groupIndex": 0,
+    "_id": "0f9RInhHlIz6exUZdIGb4W"
+  },
+  {
+    "__type__": "cc.Camera",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 3
+    },
+    "_enabled": true,
+    "_cullingMask": 4294967295,
+    "_clearFlags": 7,
+    "_backgroundColor": {
+      "__type__": "cc.Color",
+      "r": 0,
+      "g": 0,
+      "b": 0,
+      "a": 255
+    },
+    "_depth": -1,
+    "_zoomRatio": 1,
+    "_targetTexture": null,
+    "_id": "f8GU+k7BZAzZMGsVz/E4S0"
+  },
+  {
+    "__type__": "cc.Node",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 2
+    },
+    "_id": "d3hmw69ERDlb1WfnFgcl6x",
+    "_prefab": {
+      "__id__": 6
+    },
+    "_name": "Background",
+    "_active": true,
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_rotationX": 0,
+    "_rotationY": 0
+  },
+  {
+    "__type__": "cc.PrefabInfo",
+    "root": {
+      "__id__": 5
+    },
+    "asset": {
+      "__uuid__": "b8392351-be97-4f01-985e-3e7d2118f3c9"
+    },
+    "fileId": "78fd70+ls5GgJcFkzvLSRk8",
+    "sync": true
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Tips",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 2
+    },
+    "_children": [],
+    "_active": true,
+    "_level": 1,
+    "_components": [
+      {
+        "__id__": 8
+      }
+    ],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 655.63,
+      "height": 40
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0.5,
+      "y": 0.5
+    },
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_rotationX": 0,
+    "_rotationY": 0,
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_skewX": 0,
+    "_skewY": 0,
+    "_zIndex": 0,
+    "groupIndex": 0,
+    "_id": "6faW8G1K1Fo7jHvqBU0cjX"
+  },
+  {
+    "__type__": "cc.Label",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 7
+    },
+    "_enabled": true,
+    "_srcBlendFactor": 1,
+    "_dstBlendFactor": 771,
+    "_useOriginalSize": false,
+    "_string": "该场景用于测试 IOS Native 应用边界",
+    "_N$string": "该场景用于测试 IOS Native 应用边界",
+    "_fontSize": 40,
+    "_lineHeight": 40,
+    "_enableWrapText": true,
+    "_N$file": null,
+    "_isSystemFontUsed": true,
+    "_spacingX": 0,
+    "_N$horizontalAlign": 1,
+    "_N$verticalAlign": 1,
+    "_N$fontFamily": "Arial",
+    "_N$overflow": 0,
+    "_id": "6aj2XwyhhAXKrFCq0TjCPv"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Graphics",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 2
+    },
+    "_children": [],
+    "_active": true,
+    "_level": 1,
+    "_components": [
+      {
+        "__id__": 10
+      }
+    ],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 0,
+      "height": 0
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0.5,
+      "y": 0.5
+    },
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_rotationX": 0,
+    "_rotationY": 0,
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_skewX": 0,
+    "_skewY": 0,
+    "_zIndex": 0,
+    "groupIndex": 0,
+    "_id": "e98qT02OpNobS7MglnPgHb"
+  },
+  {
+    "__type__": "cc.Graphics",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 9
+    },
+    "_enabled": true,
+    "_srcBlendFactor": 770,
+    "_dstBlendFactor": 771,
+    "_lineWidth": 2,
+    "_strokeColor": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 0,
+      "b": 0,
+      "a": 255
+    },
+    "_lineJoin": 2,
+    "_lineCap": 0,
+    "_fillColor": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_miterLimit": 10,
+    "_id": "14kH/0rjxKO4M5uyxtJV9H"
+  },
+  {
+    "__type__": "cc.Canvas",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 2
+    },
+    "_enabled": true,
+    "_designResolution": {
+      "__type__": "cc.Size",
+      "width": 960,
+      "height": 640
+    },
+    "_fitWidth": false,
+    "_fitHeight": true,
+    "_id": "a2FIZpreZHUY6EwDGI86nD"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "SafeAreaCtrl",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 1
+    },
+    "_children": [],
+    "_active": true,
+    "_level": 1,
+    "_components": [
+      {
+        "__id__": 13
+      }
+    ],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 0,
+      "height": 0
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0.5,
+      "y": 0.5
+    },
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": 480,
+      "y": 320,
+      "z": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_rotationX": 0,
+    "_rotationY": 0,
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_skewX": 0,
+    "_skewY": 0,
+    "_zIndex": 0,
+    "groupIndex": 0,
+    "_id": "93jAYcE69NcpEHMuC2mq7l"
+  },
+  {
+    "__type__": "fefb3kgNq9MhpUV3012X6AE",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 12
+    },
+    "_enabled": true,
+    "tip": {
+      "__id__": 8
+    },
+    "graphics": {
+      "__id__": 10
+    },
+    "_id": "ffD1YYPDJHa7RVdF8p66YT"
+  }
+]

--- a/assets/cases/02_ui/16_safeArea/IOS_SafeArea.fire.meta
+++ b/assets/cases/02_ui/16_safeArea/IOS_SafeArea.fire.meta
@@ -1,0 +1,7 @@
+{
+  "ver": "1.0.0",
+  "uuid": "a2968b9d-92ff-4e69-9687-1710460078be",
+  "asyncLoadAssets": false,
+  "autoReleaseAssets": false,
+  "subMetas": {}
+}

--- a/assets/cases/02_ui/16_safeArea/SafeArea.meta
+++ b/assets/cases/02_ui/16_safeArea/SafeArea.meta
@@ -1,0 +1,7 @@
+{
+  "ver": "1.0.1",
+  "uuid": "e1ae3372-b93e-472d-ad61-cffd22fefef4",
+  "isSubpackage": false,
+  "subpackageName": "",
+  "subMetas": {}
+}

--- a/assets/cases/02_ui/16_safeArea/SafeArea/SafeAreaCtrl.js
+++ b/assets/cases/02_ui/16_safeArea/SafeArea/SafeAreaCtrl.js
@@ -1,0 +1,38 @@
+cc.Class({
+    extends: cc.Component,
+
+    properties: {
+        tip: cc.Label,
+        graphics: cc.Graphics,
+        _rightMenu:cc.Node,
+        _rect: cc.Rect
+    },
+
+    start () {
+        if (!cc.sys.isMobile || cc.sys.platform === cc.sys.ANDROID) {
+            return;
+        }
+        this._rect = cc.sys.getSafeAreaRect();
+        let canvasRect = cc.winSize;
+        this._rect = this.convertToLocationCanvas(this._rect);
+        this.graphics.rect(-canvasRect.width / 2 + this._rect.x, -canvasRect.height / 2 + this._rect.y, this._rect.width, this._rect.height)
+        this.graphics.fillColor = new cc.color(241, 148, 138, 66);
+        this.graphics.fill();
+        this.graphics.stroke();
+        this.tip.string = this._rect;
+
+         // move menu btns to safe area
+        this._rightMenu = cc.find('Menu/Right Menu');
+        this._rightMenu.x -= this._rect.x;
+    },
+
+    convertToLocationCanvas (rect) {
+        let ratioX = cc.view.getScaleX();
+        let ratioY = cc.view.getScaleY();
+        return cc.rect(rect.x / ratioX, rect.y / ratioY, rect.width / ratioX, rect.height / ratioY);
+    },
+
+    onDisable () {
+        this._rightMenu.x += this._rect.x;
+    }
+});

--- a/assets/cases/02_ui/16_safeArea/SafeArea/SafeAreaCtrl.js.meta
+++ b/assets/cases/02_ui/16_safeArea/SafeArea/SafeAreaCtrl.js.meta
@@ -1,0 +1,9 @@
+{
+  "ver": "1.0.5",
+  "uuid": "fefb3920-36af-4c86-9515-df4d765fa004",
+  "isPlugin": false,
+  "loadPluginInWeb": true,
+  "loadPluginInNative": true,
+  "loadPluginInEditor": false,
+  "subMetas": {}
+}

--- a/assets/scripts/Tips/TipsManager.js
+++ b/assets/scripts/Tips/TipsManager.js
@@ -18,7 +18,7 @@ module.exports = {
             case 'render_to_canvas':    return (!cc.sys.isNative && cc.sys.platform !== cc.sys.QQ_PLAY && cc.sys.platform !== cc.sys.WECHAT_GAME);
             case 'MousePropagation':    return ((cc.sys.isNative && !cc.sys.isMobile && cc.sys.platform !== cc.sys.WECHAT_GAME && cc.sys.platform !== cc.sys.QQ_PLAY) || cc.sys.platform === cc.sys.DESKTOP_BROWSER);
             case 'downloader-native':   return cc.sys.isNative;
-
+            case 'IOS_SafeArea':        return cc.sys.isMobile && cc.sys.os === cc.sys.OS_IOS;
             // 不支持 QQ_PLAY，WECHAT_GAME 平台
             case 'render_to_sprite':
                 return (cc.sys.platform !== cc.sys.QQ_PLAY && cc.sys.platform !== cc.sys.WECHAT_GAME);


### PR DESCRIPTION
Re: https://github.com/cocos-creator/example-cases/issues/582
![ebe79d7f-2bfd-e1e5-8184-e6310b48ac15](https://user-images.githubusercontent.com/35832931/47080045-8c15ae00-d239-11e8-98ca-efcf6ef36b8a.png)
![f46165a4-5776-73e6-249f-4bdb29d41fab](https://user-images.githubusercontent.com/35832931/47080046-8d46db00-d239-11e8-878e-44c79af9ff50.png)

只开放 ios 平台。
getSafeAreaRect 获取的是 view 像素大小，所以需要添加一层计算，将坐标定位为 canvas 坐标大小。