### PR TITLE
sort the capture scene scripts

### DIFF
--- a/assets/cases/07_capture_texture/capture_to_native.fire
+++ b/assets/cases/07_capture_texture/capture_to_native.fire
@@ -41,8 +41,8 @@
     },
     "_scale": {
       "__type__": "cc.Vec3",
-      "x": 0.70625,
-      "y": 0.70625,
+      "x": 0.7593505859375,
+      "y": 0.7593505859375,
       "z": 1
     },
     "_quat": {
@@ -55,7 +55,7 @@
     "_zIndex": 0,
     "groupIndex": 0,
     "autoReleaseAssets": false,
-    "_id": "162e0445-d645-4470-bc67-086eb9385618"
+    "_id": "d0cbaf6d-2905-4665-94ea-080303ba0018"
   },
   {
     "__type__": "cc.Node",
@@ -72,16 +72,13 @@
         "__id__": 5
       },
       {
-        "__id__": 9
-      },
-      {
-        "__id__": 11
+        "__id__": 7
       },
       {
         "__id__": 13
       },
       {
-        "__id__": 15
+        "__id__": 19
       }
     ],
     "_active": true,
@@ -138,7 +135,7 @@
     "_skewY": 0,
     "_zIndex": 0,
     "groupIndex": 0,
-    "_id": "a65knO45VE55L03V3lckcR"
+    "_id": "fblp6MPohHUbknYqN4j/5F"
   },
   {
     "__type__": "cc.Node",
@@ -149,7 +146,7 @@
     },
     "_children": [],
     "_active": true,
-    "_level": 0,
+    "_level": 1,
     "_components": [
       {
         "__id__": 4
@@ -199,7 +196,7 @@
     "_skewY": 0,
     "_zIndex": 0,
     "groupIndex": 0,
-    "_id": "acht+Rlh9O5YSJXeah1H0m"
+    "_id": "74M64wVKpK17LZxtCCYAQV"
   },
   {
     "__type__": "cc.Camera",
@@ -209,7 +206,7 @@
       "__id__": 3
     },
     "_enabled": true,
-    "_cullingMask": -5,
+    "_cullingMask": 4294967295,
     "_clearFlags": 7,
     "_backgroundColor": {
       "__type__": "cc.Color",
@@ -221,203 +218,21 @@
     "_depth": -1,
     "_zoomRatio": 1,
     "_targetTexture": null,
-    "_id": "59xbbR++FC8aCXQPII48IJ"
+    "_id": "78o4Y2xUND35PMkSbH4voX"
   },
   {
     "__type__": "cc.Node",
-    "_name": "content",
+    "_name": "camera",
     "_objFlags": 0,
     "_parent": {
       "__id__": 2
     },
-    "_children": [
+    "_children": [],
+    "_active": true,
+    "_level": 1,
+    "_components": [
       {
         "__id__": 6
-      }
-    ],
-    "_active": true,
-    "_level": 0,
-    "_components": [
-      {
-        "__id__": 8
-      }
-    ],
-    "_prefab": null,
-    "_opacity": 255,
-    "_color": {
-      "__type__": "cc.Color",
-      "r": 255,
-      "g": 255,
-      "b": 255,
-      "a": 255
-    },
-    "_contentSize": {
-      "__type__": "cc.Size",
-      "width": 300,
-      "height": 300
-    },
-    "_anchorPoint": {
-      "__type__": "cc.Vec2",
-      "x": 0.5,
-      "y": 0.5
-    },
-    "_position": {
-      "__type__": "cc.Vec3",
-      "x": -200,
-      "y": 0,
-      "z": 0
-    },
-    "_scale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_rotationX": 0,
-    "_rotationY": 0,
-    "_quat": {
-      "__type__": "cc.Quat",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 1
-    },
-    "_skewX": 0,
-    "_skewY": 0,
-    "_zIndex": 0,
-    "groupIndex": 0,
-    "_id": "5fAYCOtoBFhp7+NOuCN73E"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "goldcoin",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 5
-    },
-    "_children": [],
-    "_active": true,
-    "_level": 0,
-    "_components": [
-      {
-        "__id__": 7
-      }
-    ],
-    "_prefab": null,
-    "_opacity": 255,
-    "_color": {
-      "__type__": "cc.Color",
-      "r": 255,
-      "g": 255,
-      "b": 255,
-      "a": 255
-    },
-    "_contentSize": {
-      "__type__": "cc.Size",
-      "width": 80,
-      "height": 80
-    },
-    "_anchorPoint": {
-      "__type__": "cc.Vec2",
-      "x": 0.5,
-      "y": 0.5
-    },
-    "_position": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    },
-    "_scale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_rotationX": 0,
-    "_rotationY": 0,
-    "_quat": {
-      "__type__": "cc.Quat",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 1
-    },
-    "_skewX": 0,
-    "_skewY": 0,
-    "_zIndex": 0,
-    "groupIndex": 0,
-    "_id": "68e7IARiZCzLEQU8gjYi+x"
-  },
-  {
-    "__type__": "cc.Sprite",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 6
-    },
-    "_enabled": true,
-    "_srcBlendFactor": 770,
-    "_dstBlendFactor": 771,
-    "_spriteFrame": {
-      "__uuid__": "e304a643-7e04-4e85-a821-d14986bb562c"
-    },
-    "_type": 0,
-    "_sizeMode": 1,
-    "_fillType": 0,
-    "_fillCenter": {
-      "__type__": "cc.Vec2",
-      "x": 0,
-      "y": 0
-    },
-    "_fillStart": 0,
-    "_fillRange": 0,
-    "_isTrimmedMode": true,
-    "_state": 0,
-    "_atlas": null,
-    "_id": "18c5HyKfxFKYveP0VpYGHi"
-  },
-  {
-    "__type__": "cc.Sprite",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 5
-    },
-    "_enabled": true,
-    "_srcBlendFactor": 770,
-    "_dstBlendFactor": 771,
-    "_spriteFrame": {
-      "__uuid__": "bf867cae-8a21-4fff-9dad-d21b5098a1a6"
-    },
-    "_type": 0,
-    "_sizeMode": 0,
-    "_fillType": 0,
-    "_fillCenter": {
-      "__type__": "cc.Vec2",
-      "x": 0,
-      "y": 0
-    },
-    "_fillStart": 0,
-    "_fillRange": 0,
-    "_isTrimmedMode": true,
-    "_state": 0,
-    "_atlas": null,
-    "_id": "00Jv8oID1KZIaelELrbtgF"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "render_camera",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 2
-    },
-    "_children": [],
-    "_active": true,
-    "_level": 0,
-    "_components": [
-      {
-        "__id__": 10
       }
     ],
     "_prefab": null,
@@ -464,17 +279,17 @@
     "_skewY": 0,
     "_zIndex": 0,
     "groupIndex": 0,
-    "_id": "8fk7WDPmBKIL2m4iMMY2Oo"
+    "_id": "2ccZvTD8RENJuaN2BaQZtZ"
   },
   {
     "__type__": "cc.Camera",
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 9
+      "__id__": 5
     },
     "_enabled": true,
-    "_cullingMask": -5,
+    "_cullingMask": -7,
     "_clearFlags": 6,
     "_backgroundColor": {
       "__type__": "cc.Color",
@@ -486,198 +301,28 @@
     "_depth": 0,
     "_zoomRatio": 1,
     "_targetTexture": null,
-    "_id": "b74JWjjBtL4ZLWW7n6DFjp"
+    "_id": "982TDQdPNMPLK+y/EepRZs"
   },
   {
     "__type__": "cc.Node",
-    "_name": "sprite",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 2
-    },
-    "_children": [],
-    "_active": true,
-    "_level": 0,
-    "_components": [
-      {
-        "__id__": 12
-      }
-    ],
-    "_prefab": null,
-    "_opacity": 255,
-    "_color": {
-      "__type__": "cc.Color",
-      "r": 255,
-      "g": 255,
-      "b": 255,
-      "a": 255
-    },
-    "_contentSize": {
-      "__type__": "cc.Size",
-      "width": 0,
-      "height": 0
-    },
-    "_anchorPoint": {
-      "__type__": "cc.Vec2",
-      "x": 0.5,
-      "y": 0.5
-    },
-    "_position": {
-      "__type__": "cc.Vec3",
-      "x": 400,
-      "y": 0,
-      "z": 0
-    },
-    "_scale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_rotationX": 0,
-    "_rotationY": 0,
-    "_quat": {
-      "__type__": "cc.Quat",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 1
-    },
-    "_skewX": 0,
-    "_skewY": 0,
-    "_zIndex": 0,
-    "groupIndex": 2,
-    "_id": "5aw4DcvnJPupPVspAq+pwq"
-  },
-  {
-    "__type__": "cc.Sprite",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 11
-    },
-    "_enabled": true,
-    "_srcBlendFactor": 770,
-    "_dstBlendFactor": 771,
-    "_spriteFrame": null,
-    "_type": 0,
-    "_sizeMode": 2,
-    "_fillType": 0,
-    "_fillCenter": {
-      "__type__": "cc.Vec2",
-      "x": 0,
-      "y": 0
-    },
-    "_fillStart": 0,
-    "_fillRange": 0,
-    "_isTrimmedMode": false,
-    "_state": 0,
-    "_atlas": null,
-    "_id": "d9EY8nMsRH2Zdf3erQf8jR"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "sprite_camera",
-    "_objFlags": 0,
-    "_parent": {
-      "__id__": 2
-    },
-    "_children": [],
-    "_active": true,
-    "_level": 0,
-    "_components": [
-      {
-        "__id__": 14
-      }
-    ],
-    "_prefab": null,
-    "_opacity": 255,
-    "_color": {
-      "__type__": "cc.Color",
-      "r": 255,
-      "g": 255,
-      "b": 255,
-      "a": 255
-    },
-    "_contentSize": {
-      "__type__": "cc.Size",
-      "width": 0,
-      "height": 0
-    },
-    "_anchorPoint": {
-      "__type__": "cc.Vec2",
-      "x": 0.5,
-      "y": 0.5
-    },
-    "_position": {
-      "__type__": "cc.Vec3",
-      "x": 0,
-      "y": 0,
-      "z": 0
-    },
-    "_scale": {
-      "__type__": "cc.Vec3",
-      "x": 1,
-      "y": 1,
-      "z": 1
-    },
-    "_rotationX": 0,
-    "_rotationY": 0,
-    "_quat": {
-      "__type__": "cc.Quat",
-      "x": 0,
-      "y": 0,
-      "z": 0,
-      "w": 1
-    },
-    "_skewX": 0,
-    "_skewY": 0,
-    "_zIndex": 0,
-    "groupIndex": 0,
-    "_id": "8dK3OG0p9M9KHMSAVcgzSy"
-  },
-  {
-    "__type__": "cc.Camera",
-    "_name": "",
-    "_objFlags": 0,
-    "node": {
-      "__id__": 13
-    },
-    "_enabled": true,
-    "_cullingMask": 4,
-    "_clearFlags": 0,
-    "_backgroundColor": {
-      "__type__": "cc.Color",
-      "r": 51,
-      "g": 77,
-      "b": 120,
-      "a": 255
-    },
-    "_depth": 1,
-    "_zoomRatio": 1,
-    "_targetTexture": null,
-    "_id": "36YtsiUhlOP6mS27hH7qX/"
-  },
-  {
-    "__type__": "cc.Node",
-    "_name": "Save",
+    "_name": "New Button",
     "_objFlags": 0,
     "_parent": {
       "__id__": 2
     },
     "_children": [
       {
-        "__id__": 16
+        "__id__": 8
       }
     ],
     "_active": true,
     "_level": 1,
     "_components": [
       {
-        "__id__": 18
+        "__id__": 10
       },
       {
-        "__id__": 19
+        "__id__": 11
       }
     ],
     "_prefab": null,
@@ -701,8 +346,8 @@
     },
     "_position": {
       "__type__": "cc.Vec3",
-      "x": -201,
-      "y": -225,
+      "x": 0,
+      "y": 159,
       "z": 0
     },
     "_scale": {
@@ -724,21 +369,21 @@
     "_skewY": 0,
     "_zIndex": 0,
     "groupIndex": 0,
-    "_id": "ab0DYQ/DxOgpX70oUjRv+r"
+    "_id": "f5HekQuFdKK4v5WUYDm8lm"
   },
   {
     "__type__": "cc.Node",
     "_name": "Label",
     "_objFlags": 0,
     "_parent": {
-      "__id__": 15
+      "__id__": 7
     },
     "_children": [],
     "_active": true,
     "_level": 0,
     "_components": [
       {
-        "__id__": 17
+        "__id__": 9
       }
     ],
     "_prefab": null,
@@ -785,21 +430,21 @@
     "_skewY": 0,
     "_zIndex": 0,
     "groupIndex": 0,
-    "_id": "b4u6XLVq9M8qsmYPd7sHkl"
+    "_id": "3c3zkWZrJL9IexujCB5/UQ"
   },
   {
     "__type__": "cc.Label",
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 16
+      "__id__": 8
     },
     "_enabled": true,
     "_srcBlendFactor": 1,
     "_dstBlendFactor": 771,
     "_useOriginalSize": false,
-    "_string": "Save",
-    "_N$string": "Save",
+    "_string": "Capture",
+    "_N$string": "Capture",
     "_fontSize": 20,
     "_lineHeight": 40,
     "_enableWrapText": false,
@@ -810,14 +455,14 @@
     "_N$verticalAlign": 1,
     "_N$fontFamily": "Arial",
     "_N$overflow": 1,
-    "_id": "6b/yAH6FFDJLg3lnWnaPYG"
+    "_id": "73KP1CFvxIe4pz3ZbIiFan"
   },
   {
     "__type__": "cc.Sprite",
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 15
+      "__id__": 7
     },
     "_enabled": true,
     "_srcBlendFactor": 770,
@@ -838,14 +483,14 @@
     "_isTrimmedMode": true,
     "_state": 0,
     "_atlas": null,
-    "_id": "5fxmXHSy1CDZJQEZZpBuXF"
+    "_id": "8fGOLxPWBIpbvGWHwMMZ7X"
   },
   {
     "__type__": "cc.Button",
     "_name": "",
     "_objFlags": 0,
     "node": {
-      "__id__": 15
+      "__id__": 7
     },
     "_enabled": true,
     "transition": 2,
@@ -867,7 +512,7 @@
     "zoomScale": 1.2,
     "clickEvents": [
       {
-        "__id__": 20
+        "__id__": 12
       }
     ],
     "_N$interactable": true,
@@ -896,18 +541,18 @@
       "__uuid__": "e9ec654c-97a2-4787-9325-e6a10375219a"
     },
     "_N$hoverSprite": {
-      "__uuid__": "f0048c10-f03e-4c97-b9d3-3506e1d58952"
+      "__uuid__": "e9ec654c-97a2-4787-9325-e6a10375219a"
     },
     "hoverSprite": {
-      "__uuid__": "f0048c10-f03e-4c97-b9d3-3506e1d58952"
+      "__uuid__": "e9ec654c-97a2-4787-9325-e6a10375219a"
     },
     "_N$disabledSprite": {
       "__uuid__": "29158224-f8dd-4661-a796-1ffab537140e"
     },
     "_N$target": {
-      "__id__": 15
+      "__id__": 7
     },
-    "_id": "e8raAiQtpLWYICTi2VnLhH"
+    "_id": "d0fjVDHehLsJekb0JRAc0W"
   },
   {
     "__type__": "cc.ClickEvent",
@@ -915,8 +560,358 @@
       "__id__": 2
     },
     "component": "capture_to_native",
-    "handler": "saveImage",
+    "handler": "captureAndShow",
     "customEventData": ""
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Mask",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 2
+    },
+    "_children": [
+      {
+        "__id__": 14
+      }
+    ],
+    "_active": true,
+    "_level": 1,
+    "_components": [
+      {
+        "__id__": 18
+      }
+    ],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 300,
+      "height": 300
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0.5,
+      "y": 0.5
+    },
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": -100,
+      "z": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_rotationX": 0,
+    "_rotationY": 0,
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_skewX": 0,
+    "_skewY": 0,
+    "_zIndex": 0,
+    "groupIndex": 0,
+    "_id": "e1YgaNJ2BDq7A2DhJ3teqs"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "content",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 13
+    },
+    "_children": [
+      {
+        "__id__": 15
+      }
+    ],
+    "_active": true,
+    "_level": 2,
+    "_components": [
+      {
+        "__id__": 17
+      }
+    ],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 300,
+      "height": 300
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0.5,
+      "y": 0.5
+    },
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_rotationX": 0,
+    "_rotationY": 0,
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_skewX": 0,
+    "_skewY": 0,
+    "_zIndex": 0,
+    "groupIndex": 0,
+    "_id": "5ftqPT+rxD2qi6WHrBEC81"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "goldcoin",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 14
+    },
+    "_children": [],
+    "_active": true,
+    "_level": 0,
+    "_components": [
+      {
+        "__id__": 16
+      }
+    ],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 80,
+      "height": 80
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0.5,
+      "y": 0.5
+    },
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 0,
+      "z": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_rotationX": 0,
+    "_rotationY": 0,
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_skewX": 0,
+    "_skewY": 0,
+    "_zIndex": 0,
+    "groupIndex": 0,
+    "_id": "f9mhsiE6JL9a+qUC9aOw+q"
+  },
+  {
+    "__type__": "cc.Sprite",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 15
+    },
+    "_enabled": true,
+    "_srcBlendFactor": 770,
+    "_dstBlendFactor": 771,
+    "_spriteFrame": {
+      "__uuid__": "e304a643-7e04-4e85-a821-d14986bb562c"
+    },
+    "_type": 0,
+    "_sizeMode": 1,
+    "_fillType": 0,
+    "_fillCenter": {
+      "__type__": "cc.Vec2",
+      "x": 0,
+      "y": 0
+    },
+    "_fillStart": 0,
+    "_fillRange": 0,
+    "_isTrimmedMode": true,
+    "_state": 0,
+    "_atlas": null,
+    "_id": "f3YE/YTVFGX76W29Jrh8QA"
+  },
+  {
+    "__type__": "cc.Sprite",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 14
+    },
+    "_enabled": true,
+    "_srcBlendFactor": 770,
+    "_dstBlendFactor": 771,
+    "_spriteFrame": {
+      "__uuid__": "bf867cae-8a21-4fff-9dad-d21b5098a1a6"
+    },
+    "_type": 0,
+    "_sizeMode": 0,
+    "_fillType": 0,
+    "_fillCenter": {
+      "__type__": "cc.Vec2",
+      "x": 0,
+      "y": 0
+    },
+    "_fillStart": 0,
+    "_fillRange": 0,
+    "_isTrimmedMode": true,
+    "_state": 0,
+    "_atlas": null,
+    "_id": "845qp+maJPJIczJyImkBvr"
+  },
+  {
+    "__type__": "cc.Mask",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 13
+    },
+    "_enabled": true,
+    "_srcBlendFactor": 770,
+    "_dstBlendFactor": 771,
+    "_spriteFrame": null,
+    "_type": 1,
+    "_segments": 64,
+    "_N$alphaThreshold": 0,
+    "_N$inverted": false,
+    "_id": "659KkR3VdPMqHJbty7yly3"
+  },
+  {
+    "__type__": "cc.Node",
+    "_name": "Tip",
+    "_objFlags": 0,
+    "_parent": {
+      "__id__": 2
+    },
+    "_children": [],
+    "_active": true,
+    "_level": 1,
+    "_components": [
+      {
+        "__id__": 20
+      }
+    ],
+    "_prefab": null,
+    "_opacity": 255,
+    "_color": {
+      "__type__": "cc.Color",
+      "r": 255,
+      "g": 255,
+      "b": 255,
+      "a": 255
+    },
+    "_contentSize": {
+      "__type__": "cc.Size",
+      "width": 448.96,
+      "height": 40
+    },
+    "_anchorPoint": {
+      "__type__": "cc.Vec2",
+      "x": 0.5,
+      "y": 0.5
+    },
+    "_position": {
+      "__type__": "cc.Vec3",
+      "x": 0,
+      "y": 238,
+      "z": 0
+    },
+    "_scale": {
+      "__type__": "cc.Vec3",
+      "x": 1,
+      "y": 1,
+      "z": 1
+    },
+    "_rotationX": 0,
+    "_rotationY": 0,
+    "_quat": {
+      "__type__": "cc.Quat",
+      "x": 0,
+      "y": 0,
+      "z": 0,
+      "w": 1
+    },
+    "_skewX": 0,
+    "_skewY": 0,
+    "_zIndex": 0,
+    "groupIndex": 1,
+    "_id": "cc8jd4AyJI8rVTDYC8R4QR"
+  },
+  {
+    "__type__": "cc.Label",
+    "_name": "",
+    "_objFlags": 0,
+    "node": {
+      "__id__": 19
+    },
+    "_enabled": true,
+    "_srcBlendFactor": 1,
+    "_dstBlendFactor": 771,
+    "_useOriginalSize": false,
+    "_string": "该场景仅支持 native 平台",
+    "_N$string": "该场景仅支持 native 平台",
+    "_fontSize": 40,
+    "_lineHeight": 40,
+    "_enableWrapText": true,
+    "_N$file": null,
+    "_isSystemFontUsed": true,
+    "_spacingX": 0,
+    "_N$horizontalAlign": 1,
+    "_N$verticalAlign": 1,
+    "_N$fontFamily": "Arial",
+    "_N$overflow": 0,
+    "_id": "4dNQEaFcZEqY9PQhSDeBub"
   },
   {
     "__type__": "cc.Canvas",
@@ -933,22 +928,23 @@
     },
     "_fitWidth": false,
     "_fitHeight": true,
-    "_id": "66Xw1CnlpIRqG1w3FrFo8f"
+    "_id": "dfQ+9XJXhJW62Sc4VabHbs"
   },
   {
-    "__type__": "67ec9/MsdtPTI6ozOcKQcAR",
+    "__type__": "c1a65pebNpA27eOgsyL77g/",
     "_name": "",
     "_objFlags": 0,
     "node": {
       "__id__": 2
     },
     "_enabled": true,
-    "sprite": {
-      "__id__": 12
-    },
     "camera": {
-      "__id__": 10
+      "__id__": 6
     },
-    "_id": "2b6LI4dIxPjZ0kDLQ1FpO3"
+    "label": {
+      "__id__": 20
+    },
+    "_canvas": null,
+    "_id": "e7JEXjAOVPrZYA+kg90604"
   }
 ]

--- a/assets/cases/07_capture_texture/capture_to_native.fire.meta
+++ b/assets/cases/07_capture_texture/capture_to_native.fire.meta
@@ -1,6 +1,6 @@
 {
   "ver": "1.0.0",
-  "uuid": "162e0445-d645-4470-bc67-086eb9385618",
+  "uuid": "d0cbaf6d-2905-4665-94ea-080303ba0018",
   "asyncLoadAssets": false,
   "autoReleaseAssets": false,
   "subMetas": {}

--- a/assets/cases/07_capture_texture/capture_to_native.js
+++ b/assets/cases/07_capture_texture/capture_to_native.js
@@ -1,43 +1,22 @@
 cc.Class({
-    extends: cc.Component,
-
-    properties: {
-        sprite: {
-            default: null,
-            type: cc.Sprite
-        },
-
-        camera: {
-            default: null,
-            type: cc.Camera
-        }
-    },
-
-    // LIFE-CYCLE CALLBACKS:
-
-    // onLoad () {},
+    extends: require('./textureRenderUtils'),
 
     start () {
-        let texture = new cc.RenderTexture();
-        texture.initWithSize(cc.visibleRect.width, cc.visibleRect.height);
-
-        let spriteFrame = new cc.SpriteFrame();
-        spriteFrame.setTexture(texture)
-        this.sprite.spriteFrame = spriteFrame;
-        
-        this.camera.targetTexture = texture;
-
-        this.renderTexture = texture;
+        this.init();
     },
 
-    // update (dt) {},
+    captureAndShow () {
+        this.createSprite();
+        let img = this.initImage();
+        this.showSprite(img);
+        this.saveFile();
+    },
 
-    saveImage () {
+    saveFile () {
         if (CC_JSB) {
-
-            let data = this.renderTexture.readPixels();
-            let width = this.renderTexture.width;
-            let height = this.renderTexture.height;
+            let data = this.texture.readPixels();
+            let width = this.texture.width;
+            let height = this.texture.height;
             let picData = this.filpYImage(data, width, height);
 
             let filePath = jsb.fileUtils.getWritablePath() + 'render_to_sprite_image.png';
@@ -60,14 +39,14 @@ cc.Class({
         let picData = new Uint8Array(width * height * 4);
         let rowBytes = width * 4;
         for (let row = 0; row < height; row++) {
-            let reStart = row * width * 4;
             let srow = height - 1 - row;
             let start = srow * width * 4;
+            let reStart = row * width * 4;
             // save the piexls data
             for (let i = 0; i < rowBytes; i++) {
                 picData[reStart + i] = data[start + i];
             }
         }    
         return picData;
-    }
-});
+    }       
+}); 

--- a/assets/cases/07_capture_texture/capture_to_web.fire
+++ b/assets/cases/07_capture_texture/capture_to_web.fire
@@ -41,8 +41,8 @@
     },
     "_scale": {
       "__type__": "cc.Vec3",
-      "x": 0.70625,
-      "y": 0.70625,
+      "x": 0.7593505859375,
+      "y": 0.7593505859375,
       "z": 1
     },
     "_quat": {
@@ -289,7 +289,7 @@
       "__id__": 5
     },
     "_enabled": true,
-    "_cullingMask": -5,
+    "_cullingMask": -7,
     "_clearFlags": 6,
     "_backgroundColor": {
       "__type__": "cc.Color",
@@ -885,7 +885,7 @@
     "_skewX": 0,
     "_skewY": 0,
     "_zIndex": 0,
-    "groupIndex": 0,
+    "groupIndex": 1,
     "_id": "beBoz8Hm5DuoD0TEwUoH+u"
   },
   {
@@ -944,6 +944,7 @@
     "label": {
       "__id__": 20
     },
+    "_canvas": null,
     "_id": "caRvrwykBOkIkRxVlJW8L/"
   }
 ]

--- a/assets/cases/07_capture_texture/capture_to_web.js
+++ b/assets/cases/07_capture_texture/capture_to_web.js
@@ -1,104 +1,25 @@
 cc.Class({
-    extends: cc.Component,
+    extends: require('./textureRenderUtils'),
 
-    properties: {
-        camera: {
-            default: null,
-            type: cc.Camera
-        },
-        label: cc.Label
-    },
-    
     start () {
-        let texture = new cc.RenderTexture();
-        this.label.string = '';
-        let gl = cc.game._renderContext;
-        texture.initWithSize(cc.visibleRect.width, cc.visibleRect.height, gl.STENCIL_INDEX8);
-        this.camera.targetTexture = texture;
-        this.texture = texture;
-    },
-
-    capture () {
-        let width = this.texture.width;
-        let height = this.texture.height;
-
-        let canvas = document.createElement('canvas');
-        let ctx = canvas.getContext('2d');
-        canvas.width = width;
-        canvas.height = height;
-
-        this.camera.render();
-        let data = this.texture.readPixels();
-        
-        let rowBytes = width * 4;
-        for (let row = 0; row < height; row++) {
-            let srow = height - 1 - row;
-            let imageData = ctx.createImageData(width, 1);
-            let start = srow*width*4;
-            for (let i = 0; i < rowBytes; i++) {
-                imageData.data[i] = data[start+i];
-            }
-
-            ctx.putImageData(imageData, 0, row);
-        }
-        // return the type and dataUrl
-        var dataURL = canvas.toDataURL("image/png");
-        var img = document.createElement("img");
-        img.src = dataURL;
-        return img;
+        this.init();
     },
 
     captureAndShow () {
-        var img = this.capture();
-
-        // You can save the image or show it.
-
-        // img.style.position = 'absolute';
-        // img.style.display = 'block';
-        // img.style.left = '0px'
-        // img.style.top = '0px';
-        // img.zIndex = 100;
-
-        // img.style.transform = cc.game.container.style.transform;
-        // img.style['transform-origin'] = cc.game.container.style['transform-origin'];
-        // img.style.margin = cc.game.container.style.margin;
-        // img.style.padding = cc.game.container.style.padding;
-
-        // img.onclick = function (event) {
-        //     event.stopPropagation();
-        //     img.remove();
-        // }
-
-        // document.body.appendChild(img);
-
-        let texture = new cc.Texture2D();
-        texture.initWithElement(img);
-
-        let spriteFrame = new cc.SpriteFrame();
-        spriteFrame.setTexture(texture);
-
-        let node = new cc.Node();
-        let sprite = node.addComponent(cc.Sprite);
-        sprite.spriteFrame = spriteFrame;
-
-        node.zIndex = cc.macro.MAX_ZINDEX;
-        node.parent = cc.director.getScene();
-        node.x = cc.winSize.width/2;
-        node.y = cc.winSize.height/2;
-        node.on(cc.Node.EventType.TOUCH_START, () => {
-            node.parent = null;
-        });
+        this.createSprite();
+        var img = this.initImage();
+        this.showSprite(img);
         // download the pic as the file to your local
-        function saveFile (fileName, dataUrl) {
-            let a = document.createElement('a');
-            a.href = dataUrl;
-            a.download = fileName;
-            const event = document.createEvent('MouseEvents');
-            event.initMouseEvent('click', true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-            a.dispatchEvent(event);
-        }
+        this.label.string = 'Showing the capture'
+        this.saveFile('capture_to_web.png', img.src);
+    },
 
-        saveFile('capture_to_web.png', img.src);
+    saveFile (fileName, dataUrl) {
+        let a = document.createElement('a');
+        a.href = dataUrl;
+        a.download = fileName;
+        const event = document.createEvent('MouseEvents');
+        event.initMouseEvent('click', true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
+        a.dispatchEvent(event);
     }
-
 });

--- a/assets/cases/07_capture_texture/capture_to_wechat.fire
+++ b/assets/cases/07_capture_texture/capture_to_wechat.fire
@@ -41,8 +41,8 @@
     },
     "_scale": {
       "__type__": "cc.Vec3",
-      "x": 0.6890624999999999,
-      "y": 0.6890624999999999,
+      "x": 0.7593505859375,
+      "y": 0.7593505859375,
       "z": 1
     },
     "_quat": {
@@ -289,7 +289,7 @@
       "__id__": 5
     },
     "_enabled": true,
-    "_cullingMask": -5,
+    "_cullingMask": -7,
     "_clearFlags": 6,
     "_backgroundColor": {
       "__type__": "cc.Color",
@@ -560,7 +560,7 @@
       "__id__": 2
     },
     "component": "capture_to_wechat",
-    "handler": "capture",
+    "handler": "captureAndShow",
     "customEventData": ""
   },
   {
@@ -885,7 +885,7 @@
     "_skewX": 0,
     "_skewY": 0,
     "_zIndex": 0,
-    "groupIndex": 0,
+    "groupIndex": 1,
     "_id": "a3PmffmThB7aRK8GFXOc3E"
   },
   {
@@ -944,6 +944,7 @@
     "label": {
       "__id__": 20
     },
+    "_tempFilePath": null,
     "_id": "3eeB1v7z9M2acuEKEiddiw"
   }
 ]

--- a/assets/cases/07_capture_texture/capture_to_wechat.js
+++ b/assets/cases/07_capture_texture/capture_to_wechat.js
@@ -1,25 +1,18 @@
 cc.Class({
-    extends: cc.Component,
-
-    properties: {
-        camera: {
-            default: null,
-            type: cc.Camera
-        },
-        label: cc.Label
-    },
+    extends: require('./textureRenderUtils'),
 
     start () {
-        this.label.string = '';
-        let texture = new cc.RenderTexture();
-        let gl = cc.game._renderContext;
-        texture.initWithSize(cc.visibleRect.width, cc.visibleRect.height, gl.STENCIL_INDEX8);
-        this.camera.targetTexture = texture;
-        this.texture = texture;
+        this.init();
     },
 
-    capture () {
-        let tempCanvas = this.createTexture();
+    captureAndShow () {
+        let canvas = this.createSprite();
+        var img = this.initImage();
+        this.showSprite(img);
+        this.saveFile(canvas);
+    },
+
+    saveFile (tempCanvas) {
         // This is one of the ways that could save the img to your local.
         if (cc.sys.platform === cc.sys.WECHAT_GAME) {
             let self = this;
@@ -32,49 +25,20 @@ cc.Class({
                 destWidth: canvas.width,
                 destHeight: canvas.height,
                 fileType: 'png',
-                quality: 1,
+                quality: 1
+            }
+            // https://developers.weixin.qq.com/minigame/dev/api/render/canvas/Canvas.toTempFilePathSync.html
+            let _tempFilePath = tempCanvas.toTempFilePathSync(data);
+            cc.log(`Capture file success!${_tempFilePath}`);
+            self.label.string = '图片加载完成，等待本地预览';
+            // https://developers.weixin.qq.com/minigame/dev/api/media/image/wx.previewImage.html
+            wx.previewImage({
+                urls: [_tempFilePath],
                 success: (res) => {
-                    console.log(`Capture file success!${res.tempFilePath}`);
-                    self.label.string = '图片加载完成，等待本地预览';
-                    // https://developers.weixin.qq.com/minigame/dev/api/media/image/wx.previewImage.html
-                    wx.previewImage({
-                        urls: [res.tempFilePath],
-                        success: (res) => {
-                            console.log('Preview image success.');
-                            self.label.string = '';
-                        }
-                    });
+                    cc.log('Preview image success.');
+                    self.label.string = '';
                 }
-            }
-            // https://developers.weixin.qq.com/minigame/dev/api/render/canvas/Canvas.toTempFilePath.html
-            tempCanvas.toTempFilePath(data);
+            });
         }
-    },
-
-    createTexture () {
-        let width = this.texture.width;
-        let height = this.texture.height;
-
-        let canvas = document.createElement('canvas');
-        let ctx = canvas.getContext('2d');
-
-        canvas.width = width;
-        canvas.height = height;
-
-        this.camera.render();
-        let data = this.texture.readPixels();
-        // write the render data
-        let rowBytes = width * 4; 
-        for (let row = 0; row < height; row++) {
-            let srow = height - 1 - row;
-            let imageData = ctx.createImageData(width, 1);
-            let start = srow*width*4;
-            for (let i = 0; i < rowBytes; i++) {
-                imageData.data[i] = data[start+i];
-            }
-
-            ctx.putImageData(imageData, 0, row);
-        }
-        return canvas;
     }
 });

--- a/assets/cases/07_capture_texture/textureRenderUtils.js
+++ b/assets/cases/07_capture_texture/textureRenderUtils.js
@@ -1,0 +1,83 @@
+cc.Class({
+    extends: cc.Component,
+
+    properties: {
+        camera: cc.Camera,
+        label: cc.Label,
+        _canvas: null
+    },
+
+    init () {
+        this.label.string = '';
+        let texture = new cc.RenderTexture();
+        let gl = cc.game._renderContext;
+        texture.initWithSize(cc.visibleRect.width, cc.visibleRect.height, gl.STENCIL_INDEX8);
+        this.camera.targetTexture = texture;
+        this.texture = texture;
+    },
+    // create the img element
+    initImage () {
+        // return the type and dataUrl
+        var dataURL = this._canvas.toDataURL("image/png");
+        var img = document.createElement("img");
+        img.src = dataURL;
+        return img;
+    },
+    // create the canvas and context, filpY the image Data
+    createSprite () {
+        let width = this.texture.width;
+        let height = this.texture.height;
+        if (!this._canvas) {
+            this._canvas = document.createElement('canvas');
+    
+            this._canvas.width = width;
+            this._canvas.height = height;
+        }
+        else {
+            this.clearCanvas();
+        }
+        let ctx = this._canvas.getContext('2d');
+        this.camera.render();
+        let data = this.texture.readPixels();
+        // write the render data
+        let rowBytes = width * 4; 
+        for (let row = 0; row < height; row++) {
+            let srow = height - 1 - row;
+            let imageData = ctx.createImageData(width, 1);
+            let start = srow * width * 4;
+            for (let i = 0; i < rowBytes; i++) {
+                imageData.data[i] = data[start + i];
+            }
+
+            ctx.putImageData(imageData, 0, row);
+        }
+        return this._canvas;
+    },
+    // show on the canvas
+    showSprite (img) {
+        let texture = new cc.Texture2D();
+        texture.initWithElement(img);
+
+        let spriteFrame = new cc.SpriteFrame();
+        spriteFrame.setTexture(texture);
+
+        let node = new cc.Node();
+        let sprite = node.addComponent(cc.Sprite);
+        sprite.spriteFrame = spriteFrame;
+
+        node.zIndex = cc.macro.MAX_ZINDEX;
+        node.parent = cc.director.getScene();
+        node.x = cc.winSize.width / 2;
+        node.y = cc.winSize.height / 2;
+        node.on(cc.Node.EventType.TOUCH_START, () => {
+            node.parent = null;
+            this.label.string = '';
+            node.destroy();
+        }); 
+    },
+
+    clearCanvas () {
+        let ctx = this._canvas.getContext('2d');
+        ctx.clearRect(0, 0, this._canvas.width, this._canvas.height);
+    }
+});

--- a/assets/cases/07_capture_texture/textureRenderUtils.js.meta
+++ b/assets/cases/07_capture_texture/textureRenderUtils.js.meta
@@ -1,6 +1,6 @@
 {
   "ver": "1.0.5",
-  "uuid": "c1a65a5e-6cda-40db-b78e-82cc8befb83f",
+  "uuid": "a8867ef7-c7ea-4468-91ad-c06b44884f6a",
   "isPlugin": false,
   "loadPluginInWeb": true,
   "loadPluginInNative": true,


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/719
Re: https://github.com/cocos-creator/2d-tasks/issues/730
Re: https://github.com/cocos-creator/2d-tasks/issues/737
1. 整理现有的三个截图场景，让每个场景都具有展示 sprite 的功能，并且具有保存正确方向截图的能力。

2. 提取了部分可公用代码，试每个场景脚本内容更新家清晰。

render_to_sprite 已被清除，更换为 capture_to_native