### PR TITLE
fixed the mobile download the capture image failed problem

### DIFF
--- a/assets/cases/07_capture_texture/capture_to_web.js
+++ b/assets/cases/07_capture_texture/capture_to_web.js
@@ -11,15 +11,34 @@ cc.Class({
         this.showSprite(img);
         // download the pic as the file to your local
         this.label.string = 'Showing the capture'
-        this.saveFile('capture_to_web.png', img.src);
+        this.downloadFile('capture_to_web.png', img.src);
     },
 
-    saveFile (fileName, dataUrl) {
-        let a = document.createElement('a');
-        a.href = dataUrl;
-        a.download = fileName;
-        const event = document.createEvent('MouseEvents');
-        event.initMouseEvent('click', true, false, window, 0, 0, 0, 0, 0, false, false, false, false, 0, null);
-        a.dispatchEvent(event);
-    }
+    base64Img2Blob(code){
+        var parts = code.split(';base64,');
+        var contentType = parts[0].split(':')[1];
+        var raw = window.atob(parts[1]);
+        var rawLength = raw.length;
+
+        var uInt8Array = new Uint8Array(rawLength);
+
+        for (var i = 0; i < rawLength; ++i) {
+          uInt8Array[i] = raw.charCodeAt(i);
+        }
+
+        return new Blob([uInt8Array], {type: contentType}); 
+    },
+
+    downloadFile (fileName, content){      
+        var aLink = document.createElement('a');
+        var blob = this.base64Img2Blob(content);
+      
+        var evt = document.createEvent("MouseEvents");
+        evt.initEvent("click", false, false);
+        aLink.download = fileName;
+        aLink.href = URL.createObjectURL(blob);
+ 
+        aLink.dispatchEvent(evt);
+    }   
+
 });


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/739

大部分的手机浏览器不支持 直接下载 base64 格式图片，因此找个办法转码成 blob 格式通过生成新的 URL 链接进行下载。

修复移动端浏览器下载 capture image 失败问题