### PR TITLE
fix when change aim direction，set fade time greater than 0，or skeleto…

### DIFF
--- a/assets/cases/dragonbones/DragonBonesCtrl.js
+++ b/assets/cases/dragonbones/DragonBonesCtrl.js
@@ -466,12 +466,12 @@ cc.Class({
             // Animation mixing.
             if (this._aimDir >= 0) {
                 this._aimState = this._armature.animation.fadeIn(
-                    "aimUp", 0, 1,
+                    "aimUp", 0.01, 1,
                     0, AIM_ANIMATION_GROUP, dragonBones.AnimationFadeOutMode.SameGroup
                 );
             } else {
                 this._aimState = this._armature.animation.fadeIn(
-                    "aimDown", 0, 1,
+                    "aimDown", 0.01, 1,
                     0, AIM_ANIMATION_GROUP, dragonBones.AnimationFadeOutMode.SameGroup
                 );
             }


### PR DESCRIPTION
在dragonBones机甲例子中，如果在updateAim的时候，调用fadeIn或者fadeOut方法，传递的fade时间为0，那么将会立即刷新动画，而此时的动画权重（weight）还未设置，会造成瞄准动画闪动的现象。