### PR TITLE
fix i18n in release mode

### DIFF
--- a/assets/i18n/polyglot.js
+++ b/assets/i18n/polyglot.js
@@ -17,15 +17,7 @@
 
 
 (function(root, factory) {
-  if (typeof define === 'function' && define.amd) {
-    define([], function() {
-      return factory(root);
-    });
-  } else if (typeof exports === 'object') {
-    module.exports = factory(root);
-  } else {
-    root.Polyglot = factory(root);
-  }
+  module.exports = factory(root);
 }(typeof global !== 'undefined' ? global : this, function(root) {
   'use strict';
 


### PR DESCRIPTION
changeLog:
- 修复百度小游戏， release 模式下报错

因为百度小游戏平台运行时，用 webpack 又做了一次打包，导致 release 模式下，require('polyglot') 失败
对于引擎项目脚本，这里用 module.exports 就行了