### PR TITLE
fix clear assets when loadResDir

### DIFF
--- a/assets/cases/05_scripting/07_asset_loading/LoadResDir/loadResDir_example.js
+++ b/assets/cases/05_scripting/07_asset_loading/LoadResDir/loadResDir_example.js
@@ -48,6 +48,7 @@ cc.Class({
         this._clear();
         this._createLabel("Load All Assets");
         this.scrollView.scrollToTop();
+        this.btnClearAll.active = false;  // 防止加载的过程中清除资源
 
         cc.loader.loadResDir("test_assets", (err, assets) => {
             if (!this.isValid) {
@@ -80,6 +81,7 @@ cc.Class({
         this._clear();
         this._createLabel("Load All Sprite Frame");
         this.scrollView.scrollToTop();
+        this.btnClearAll.active = false;  // 防止加载的过程中清除资源
 
         cc.loader.loadResDir("test_assets", cc.SpriteFrame, (err, assets) => {
             if (!this.isValid) {


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1092

05_scripting/07_asset_loading->LoadResDir 测试例中，
加载所有资源的过程中，将已经加载的 spriteFrame 释放，会造成部分 png 被 texutre 引用无法释放
