### PR TITLE
 fix cocos-creator/2d-tasks/issues/1272

### DIFF
--- a/assets/cases/3d/mesh-texture.effect.meta
+++ b/assets/cases/3d/mesh-texture.effect.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.13",
+  "ver": "1.0.14",
   "uuid": "2cae2c68-0853-4258-a25e-b2b169e07700",
   "compiledShaders": [
     {

--- a/assets/main menu/Menu.js
+++ b/assets/main menu/Menu.js
@@ -44,12 +44,6 @@ cc.Class({
             });
         }
 
-        cc.systemEvent.on(cc.SystemEvent.EventType.KEY_DOWN, (event) => {
-            if (event.keyCode === cc.macro.KEY.b || event.keyCode === cc.macro.KEY.back) {
-                this.backToList();
-            }
-        }, this);
-
         cc.director.on(cc.Director.EVENT_AFTER_SCENE_LAUNCH, this._onSceneLaunched, this);
 
         let url = this.storage.getCurrentScene();

--- a/assets/res/3d/mixamo/model.fbx.meta
+++ b/assets/res/3d/mixamo/model.fbx.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.13",
+  "ver": "1.0.14",
   "uuid": "d3ea15fb-3c29-4d96-8c92-56627ef06f12",
   "scaleFactor": 300,
   "boneCount": 52,

--- a/assets/res/3d/mixamo/model@Capoeira.fbx.meta
+++ b/assets/res/3d/mixamo/model@Capoeira.fbx.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.13",
+  "ver": "1.0.14",
   "uuid": "5c76f955-1f6c-4642-9d3c-fbe71920e957",
   "scaleFactor": 1,
   "boneCount": 52,

--- a/assets/res/3d/mixamo/model@Defeated.fbx.meta
+++ b/assets/res/3d/mixamo/model@Defeated.fbx.meta
@@ -1,5 +1,5 @@
 {
-  "ver": "1.0.13",
+  "ver": "1.0.14",
   "uuid": "b9f2d2cf-b77c-4cdf-9231-1a8b0fa67694",
   "scaleFactor": 1,
   "boneCount": 52,


### PR DESCRIPTION
https://github.com/cocos-creator/2d-tasks/issues/1272

移除 Menu.js 中的监听 back 事件，之前是为什么方便快速返回到主菜单，但是这样会影响到 videoplayer 范例，所以进行移除