### PR TITLE
make slider example scene show faster

### DIFF
--- a/assets/cases/02_ui/12_slider/Slider.fire.meta
+++ b/assets/cases/02_ui/12_slider/Slider.fire.meta
@@ -1,7 +1,7 @@
 {
   "ver": "1.2.0",
   "uuid": "d183c82d-7e87-44b5-8c65-eb99ec42b829",
-  "asyncLoadAssets": false,
+  "asyncLoadAssets": true,
   "autoReleaseAssets": true,
   "subMetas": {}
 }


### PR DESCRIPTION
re: https://github.com/cocos-creator/2d-tasks/issues/153
This problem is caused by browser's slow loading of audio resource. The method I used to fix this is to make asyncLoadAssets true which will make scene show faster.
这个问题是浏览器对音频资源读取过慢引起的，修复方法是勾选上场景的延迟加载资源即可快速进入场景。