### PR TITLE
call label default onload on example-case

### DIFF
--- a/assets/i18n/LabelLocalized.js
+++ b/assets/i18n/LabelLocalized.js
@@ -27,6 +27,7 @@ cc.Class({
     },
 
     onLoad () {
+        this._super();
         if (this.localizedString) {
             this.string = this.localizedString;
         }


### PR DESCRIPTION
关联 pr: https://github.com/cocos-creator/engine/pull/5330

LabelLocalized 组件继承自 CCLabel 组件
应该调用父类的 onLoad