### PR TITLE
fix socket-io plugin on xiaomi platform

### DIFF
--- a/assets/cases/05_scripting/11_network/socket-io.js
+++ b/assets/cases/05_scripting/11_network/socket-io.js
@@ -1,5 +1,6 @@
 !function(e){
-    if (CC_WECHATGAME) {
+    var _global = typeof window === 'undefined' ? global : window;
+    if (_global.CC_WECHATGAME) {
         var f;
         "undefined" != typeof window ? f = window : "undefined" != typeof global ? f = global : "undefined" != typeof self && (f = self), f.io = e()
     }


### PR DESCRIPTION
Re: https://github.com/cocos-creator/2d-tasks/issues/1841

changeLog:
- 修复 v2.2 上 socket-io 插件的报错

v2.2 移除了 CC_WECHATGAME 宏，CC_WECHATGAME 变成了全局变量，小米平台需要显式访问 window 的属性