### PR TITLE
fix resource loading

### DIFF
--- a/assets/cases/05_scripting/10_loadingBar/LoadingBarCtrl.js
+++ b/assets/cases/05_scripting/10_loadingBar/LoadingBarCtrl.js
@@ -27,7 +27,7 @@ cc.Class({
     // use this for initialization
     onLoad: function () {
         this._urls = [
-            cc.url.raw("resources/audio/ding.wav"),
+            cc.url.raw("resources/audio/ding.mp3"),
             cc.url.raw("resources/audio/cheering.wav"),
             cc.url.raw("resources/audio/music_logo.mp3"),
             cc.url.raw("resources/test_assets/audio.mp3"),


### PR DESCRIPTION
https://github.com/cocos-creator/2d-tasks/issues/2098

changeLog:
- 修复 loadingBar 场景资源加载路径错误的问题

<img width="399" alt="20191120143136" src="https://user-images.githubusercontent.com/17872773/69214732-a8092300-0ba2-11ea-8210-58823657c539.png">

