### PR TITLE
fix SafeArea example node name bug.

### DIFF
--- a/assets/cases/02_ui/16_safeArea/SafeArea.fire
+++ b/assets/cases/02_ui/16_safeArea/SafeArea.fire
@@ -186,7 +186,7 @@
       "array": [
         0,
         0,
-        343.8120853024222,
+        259.8076211353316,
         0,
         0,
         0,
@@ -409,7 +409,7 @@
       "__type__": "TypedArray",
       "ctor": "Float64Array",
       "array": [
-        430,
+        -430,
         0,
         0,
         0,
@@ -432,7 +432,7 @@
     "_is3DNode": false,
     "_groupIndex": 0,
     "groupIndex": 0,
-    "_id": "8aTXDuIp5KcKj93em0beDY"
+    "_id": "d5QPGstCRHk40TpxbfflzM"
   },
   {
     "__type__": "cc.Sprite",
@@ -464,7 +464,7 @@
     "_fillRange": 0,
     "_isTrimmedMode": true,
     "_atlas": null,
-    "_id": "d8rF9TXSBIj5qfroKU7pfO"
+    "_id": "e5FggfgQNPfJvaXK1DSjG1"
   },
   {
     "__type__": "cc.Widget",
@@ -476,7 +476,7 @@
     "_enabled": true,
     "alignMode": 1,
     "_target": null,
-    "_alignFlags": 32,
+    "_alignFlags": 8,
     "_left": 0,
     "_right": 0,
     "_top": 0,
@@ -491,7 +491,7 @@
     "_isAbsVerticalCenter": true,
     "_originalWidth": 0,
     "_originalHeight": 0,
-    "_id": "93yu+2HSBPZYNJ1tURYIrg"
+    "_id": "48ZbSmbO1Dg7byUs9lLhMd"
   },
   {
     "__type__": "cc.Node",
@@ -533,7 +533,7 @@
       "__type__": "TypedArray",
       "ctor": "Float64Array",
       "array": [
-        -430,
+        430,
         0,
         0,
         0,
@@ -556,7 +556,7 @@
     "_is3DNode": false,
     "_groupIndex": 0,
     "groupIndex": 0,
-    "_id": "d5QPGstCRHk40TpxbfflzM"
+    "_id": "8aTXDuIp5KcKj93em0beDY"
   },
   {
     "__type__": "cc.Sprite",
@@ -588,7 +588,7 @@
     "_fillRange": 0,
     "_isTrimmedMode": true,
     "_atlas": null,
-    "_id": "e5FggfgQNPfJvaXK1DSjG1"
+    "_id": "d8rF9TXSBIj5qfroKU7pfO"
   },
   {
     "__type__": "cc.Widget",
@@ -600,7 +600,7 @@
     "_enabled": true,
     "alignMode": 1,
     "_target": null,
-    "_alignFlags": 8,
+    "_alignFlags": 32,
     "_left": 0,
     "_right": 0,
     "_top": 0,
@@ -615,7 +615,7 @@
     "_isAbsVerticalCenter": true,
     "_originalWidth": 0,
     "_originalHeight": 0,
-    "_id": "48ZbSmbO1Dg7byUs9lLhMd"
+    "_id": "93yu+2HSBPZYNJ1tURYIrg"
   },
   {
     "__type__": "cc.Node",


### PR DESCRIPTION
fix the node's name is not match in SafeArea.fire.

![Jietu20200916-104631](https://user-images.githubusercontent.com/7514260/93287618-83a2c500-f80c-11ea-94fc-5d15a47b9ba9.jpg)
